### PR TITLE
Fixes hide. Gives them the aphro bite by request

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -339,9 +339,10 @@
 
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/sonar_ping,
-		/mob/living/proc/hide,
+		/mob/living/carbon/human/proc/hide_humanoid,
 		/mob/living/proc/shred_limb,
-		/mob/living/proc/toggle_pass_table
+		/mob/living/proc/toggle_pass_table,
+		/mob/living/carbon/human/proc/succubus_bite
 		)
 
 /datum/species/shapeshifter/promethean


### PR DESCRIPTION
- Fixes the teshari hide to make it work properly.

- Gives teshari the bite by default, since... Well, why not? They can't get it otherwise since it's a trait.