### PR TITLE
Adds more verbs for Event Manager

### DIFF
--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -266,7 +266,7 @@ var/global/list/round_voters = list() // Keeps track of the individuals voting f
 		return
 	var/admin = 0
 	if(C.holder)
-		if(C.holder.rights & R_ADMIN)
+		if(C.holder.rights & R_ADMIN|R_EVENT)
 			admin = 1
 
 	. = "<html><head><title>Voting Panel</title></head><body>"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -9,7 +9,7 @@ var/global/floorIsLava = 0
 	//log_adminwarn(msg) //log_and_message_admins is for this
 
 	for(var/client/C in admins)
-		if((R_ADMIN|R_MOD) & C.holder.rights)
+		if((R_ADMIN|R_MOD|R_EVENT) & C.holder.rights)
 			C << msg
 
 /proc/msg_admin_attack(var/text) //Toggleable Attack Messages

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -326,6 +326,7 @@ var/list/admin_verbs_hideable = list(
 	/proc/release,
 	/datum/admins/proc/set_tcrystals
 	)
+
 var/list/admin_verbs_mod = list(
 	/client/proc/cmd_admin_pm_context,	//right-click adminPM interface,
 	/client/proc/cmd_admin_pm_panel,	//admin-pm list,
@@ -403,9 +404,23 @@ var/list/admin_verbs_event_manager = list(
 	/client/proc/toggle_random_events,
 	/client/proc/editappear,
 	/client/proc/roll_dices,
+	/client/proc/cmd_admin_create_centcom_report,
+	/client/proc/trader_ship,
+	/client/proc/response_team,
+	/client/proc/cmd_admin_change_custom_event,
+	/client/proc/admin_call_shuttle,
+	/client/proc/admin_cancel_shuttle,
+	/client/proc/admin_deny_shuttle,
+	/client/proc/event_manager_panel,
+	/client/proc/secrets,
+	/datum/admins/proc/startnow,
+	/client/proc/change_security_level,
+	/datum/admins/proc/access_news_network,
 	/datum/admins/proc/call_supply_drop,
 	/datum/admins/proc/call_drop_pod
 )
+
+
 
 /client/proc/add_admin_verbs()
 	if(holder)
@@ -902,7 +917,7 @@ var/list/admin_verbs_event_manager = list(
 	set desc = "Sets the station security level"
 	set category = "Admin"
 
-	if(!check_rights(R_ADMIN))	return
+	if(!check_rights(R_ADMIN | R_EVENT))	return
 	var sec_level = input(usr, "It's currently code [get_security_level()].", "Select Security Level")  as null|anything in (list("green","blue","red","delta")-get_security_level())
 	if(alert("Switch from code [get_security_level()] to code [sec_level]?","Change security level?","Yes","No") == "Yes")
 		set_security_level(sec_level)


### PR DESCRIPTION
Verbs have been added to help Event Managers actually manage events in rounds cause it's getting fuckin' outrageous. Oh and granting them access to admin messages because they cannot see their own actions during testing.

The following verbs have been added:
> - Start-Now
> - Set security level
> - Custom Vote 
> - Create Command Report
> - Dispatch Beruang Trader Ship
> - Dispatch Emergency Response Team
> - Access Newscaster Network
> - Change Custom Event
> - Call Shuttle
> - Cancel Shuttle
> - Toggle Deny Shuttle
> - Event Manager Panel
> - Secrets
