### PR TITLE
Prommie Push/Swap Fix FINALLY!

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -349,6 +349,8 @@
 
 /datum/species/shapeshifter/promethean
 	spawn_flags = SPECIES_CAN_JOIN
+	push_flags = ~HEAVY //for some reason this fixes the issue with Prommies not being able to swap or push other players
+	swap_flags = ~HEAVY
 
 /datum/species/human
 	color_mult = 1


### PR DESCRIPTION
somehow this works, allowing prommies to swap and push other players again... don't know why the bug happened in the first place though