### PR TITLE
Halving Size Alteration Price

### DIFF
--- a/code/modules/nifsoft/software/15_misc.dm
+++ b/code/modules/nifsoft/software/15_misc.dm
@@ -122,7 +122,7 @@
 	name = "Mass Alteration"
 	desc = "A system that allows one to change their size, through drastic mass rearrangement. Causes significant wear when installed."
 	list_pos = NIF_SIZECHANGE
-	cost = 750
+	cost = 375
 	wear = 6
 
 	activate()


### PR DESCRIPTION
This will allow Visitors to purchase the ever-elusive size changing program at the NiFSoft Shop due to their allowance frequently being too low to be able to do such.