### PR TITLE
Access Adjustments NiFSoft Shop

### DIFF
--- a/code/modules/nifsoft/software/01_vision.dm
+++ b/code/modules/nifsoft/software/01_vision.dm
@@ -100,7 +100,6 @@
 	list_pos = NIF_MESONS
 	cost = 1000
 	a_drain = 0.1
-	access = access_engine
 	tick_flags = NIF_ACTIVETICK
 	planes_enabled = list(VIS_FULLBRIGHT, VIS_MESONS)
 	vision_flags = (NIF_V_MESONS)
@@ -119,7 +118,6 @@
 	list_pos = NIF_MATERIAL
 	cost = 1000
 	a_drain = 0.1
-	access = access_research
 	tick_flags = NIF_ACTIVETICK
 	planes_enabled = list(VIS_FULLBRIGHT)
 	vision_flags = (NIF_V_MATERIAL)

--- a/code/modules/nifsoft/software/01_vision.dm
+++ b/code/modules/nifsoft/software/01_vision.dm
@@ -100,6 +100,7 @@
 	list_pos = NIF_MESONS
 	cost = 1000
 	a_drain = 0.1
+	access = access_engine
 	tick_flags = NIF_ACTIVETICK
 	planes_enabled = list(VIS_FULLBRIGHT, VIS_MESONS)
 	vision_flags = (NIF_V_MESONS)
@@ -118,6 +119,7 @@
 	list_pos = NIF_MATERIAL
 	cost = 1000
 	a_drain = 0.1
+	access = access_mining
 	tick_flags = NIF_ACTIVETICK
 	planes_enabled = list(VIS_FULLBRIGHT)
 	vision_flags = (NIF_V_MATERIAL)


### PR DESCRIPTION
Nukes access requirements to material scanners as well as meson scanners in the NiFSoft Shop. You can find the mesons in various places anyway and this would also allow miners to FINALLY purchase the elusive material scanners program when they have a NiF. 

Edit: Reverting and switching access only to Material Scanners for access_mining.