### PR TITLE
HoS Armor Nerf

### DIFF
--- a/code/modules/clothing/suits/armor_vr.dm
+++ b/code/modules/clothing/suits/armor_vr.dm
@@ -29,10 +29,10 @@
 
 // HoS armor improved by Vorestation to be slightly better than normal security stuff.
 /obj/item/clothing/suit/storage/vest/hoscoat
-	armor = list(melee = 50, bullet = 40, laser = 40, energy = 25, bomb = 25, bio = 0, rad = 0)
+	armor = list(melee = 45, bullet = 35, laser = 35, energy = 30, bomb = 25, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/storage/vest/hos
-	armor = list(melee = 50, bullet = 40, laser = 40, energy = 25, bomb = 25, bio = 0, rad = 0)
+	armor = list(melee = 45, bullet = 40, laser = 40, energy = 30, bomb = 15, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/storage/vest/hoscoat/jensen
 	name = "armored trenchcoat"
@@ -59,7 +59,7 @@
 
 /obj/item/clothing/suit/armor/combat/USDF
 	name = "marine body armor"
-	desc = "When I joined the Corps, we didn't have any fancy-schmanzy armor. We had sticks! Two sticks, and a rock for the whole platoon–and we had to <i>share</i> the rock!"
+	desc = "When I joined the Corps, we didn't have any fancy-schmanzy armor. We had sticks! Two sticks, and a rock for the whole platoonâ€“and we had to <i>share</i> the rock!"
 	icon_state = "UNSC_armor"
 	icon = 'icons/obj/clothing/suits_vr.dmi'
 	icon_override = 'icons/mob/suit_vr.dmi'


### PR DESCRIPTION
The HoS armored coat was too powerful compared to other armors. The numbers have been brought down a little, but are still slightly superior to standard security vests. The head of security vest, however, was only slightly nerfed with melee being reduced by five. It keeps its superior bullet and energy protection, but bomb protection is being reduced to 15 to be just a little better than regular security vest.

Here are a list of comparison screenshots. Might need more reviews.
https://cdn.discordapp.com/attachments/405257702663782400/534594080521584661/Armor_1_Vest.PNG
https://cdn.discordapp.com/attachments/405257702663782400/534594118400213002/Armor_2_HoS.PNG
https://cdn.discordapp.com/attachments/405257702663782400/534594145436565507/Armor_3_Voidsuit.png
https://cdn.discordapp.com/attachments/405257702663782400/534594721503510533/Armor_4_New_Hardsuit.PNG
https://cdn.discordapp.com/attachments/405257702663782400/534595864317001728/Armor_5_Proposed_Trenchcoat_changes.PNG