### PR TITLE
Asteroid Mob Vore Nerf

### DIFF
--- a/code/game/objects/mob_spawner_chomp.dm
+++ b/code/game/objects/mob_spawner_chomp.dm
@@ -21,16 +21,16 @@
 		/mob/living/simple_animal/retaliate/bee = 50,
 	)
 
-	/obj/structure/mob_spawner/scanner/mining_animals/do_spawn(var/mob_path)
-		if(!ispath(mob_path))
-			return 0
-		var/mob/living/L = new mob_path(get_turf(src))
-			L/simple_animal.vore_escape_time = 15 SECONDS
-		L.source_spawner = src
-		spawned_mobs.Add(L)
-		last_spawn = world.time
-		if(total_spawns > 0)
-			total_spawns--
-		if(mob_faction)
-			L.faction = mob_faction
-		return L
+/obj/structure/mob_spawner/scanner/mining_animals/do_spawn(var/mob_path)
+	if(!ispath(mob_path))
+		return 0
+	var/mob/living/L = new mob_path(get_turf(src))
+	L/simple_animal.vore_escape_time = 15 SECONDS
+	L.source_spawner = src
+	spawned_mobs.Add(L)
+	last_spawn = world.time
+	if(total_spawns > 0)
+		total_spawns--
+	if(mob_faction)
+		L.faction = mob_faction
+	return L

--- a/code/game/objects/mob_spawner_chomp.dm
+++ b/code/game/objects/mob_spawner_chomp.dm
@@ -20,3 +20,17 @@
 		/mob/living/simple_animal/hostile/goose = 60,
 		/mob/living/simple_animal/retaliate/bee = 50,
 	)
+
+	/obj/structure/mob_spawner/scanner/mining_animals/do_spawn(var/mob_path)
+		if(!ispath(mob_path))
+			return 0
+		var/mob/living/L = new mob_path(get_turf(src))
+		L/simple_animal.vore_escape_time = 15 SECONDS
+		L.source_spawner = src
+		spawned_mobs.Add(L)
+		last_spawn = world.time
+		if(total_spawns > 0)
+			total_spawns--
+		if(mob_faction)
+			L.faction = mob_faction
+		return L

--- a/code/game/objects/mob_spawner_chomp.dm
+++ b/code/game/objects/mob_spawner_chomp.dm
@@ -25,7 +25,7 @@
 		if(!ispath(mob_path))
 			return 0
 		var/mob/living/L = new mob_path(get_turf(src))
-		L/simple_animal.vore_escape_time = 15 SECONDS
+			L/simple_animal.vore_escape_time = 15 SECONDS
 		L.source_spawner = src
 		spawned_mobs.Add(L)
 		last_spawn = world.time

--- a/code/modules/mob/living/simple_animal/simple_animal_vr.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal_vr.dm
@@ -20,6 +20,7 @@
 	var/vore_digest_chance = 25			// Chance to switch to digest mode if resisted
 	var/vore_absorb_chance = 0			// Chance to switch to absorb mode if resisted
 	var/vore_escape_chance = 25			// Chance of resisting out of mob
+	var/vore_escape_time = 60 SECONDS	// This didn't exist before. Why? I don't know. Modifies the escape time of a belly. -Erik
 
 	var/vore_stomach_name				// The name for the first belly if not "stomach"
 	var/vore_stomach_flavor				// The flavortext for the first belly if not the default
@@ -151,6 +152,7 @@
 	B.mode_flags = vore_default_flags
 	B.escapable = vore_escape_chance > 0
 	B.escapechance = vore_escape_chance
+	B.escapetime = vore_escape_time
 	B.digestchance = vore_digest_chance
 	B.absorbchance = vore_absorb_chance
 	B.human_prey_swallow_time = swallowTime


### PR DESCRIPTION
Mobs on the asteroid now have 15 second escape time for vore bellies, not 60 seconds. Now you can get ate by mobs without being punished with critical damage! (Does not affect Admemed™ mobs)