### PR TITLE
Minetroid fix

### DIFF
--- a/code/modules/mob/living/simple_animal/vore/metroidsSimple.dm
+++ b/code/modules/mob/living/simple_animal/vore/metroidsSimple.dm
@@ -106,6 +106,7 @@
 	max_co2 = 0
 	min_n2 = 0
 	max_n2 = 0
+	minbodytemp = 0
 
 
 	melee_damage_lower = 10


### PR DESCRIPTION
Minetroids were dying in space due to cold temperatures. Cold temperatures no longer affect the Minetroid.