### PR TITLE
Giving space bats random loot drops

### DIFF
--- a/code/modules/mob/living/simple_animal/animals/bat.dm
+++ b/code/modules/mob/living/simple_animal/animals/bat.dm
@@ -49,6 +49,8 @@
 
 /mob/living/simple_animal/hostile/scarybat/New(loc, mob/living/L as mob)
 	..()
+	if(prob(30))//30% should be nice for a tiny bonus of silver, at least gives fighting mobs more purpose
+		contents += "/obj/item/weapon/ore/silver" //CHOMP EDIT: Random chance for bats to carry silver
 	if(istype(L))
 		owner = L
 


### PR DESCRIPTION
Space bats now may carry silver, because SHINY!

Also they want me to tell you theat they are TOTALLY SCARY and not at all cute lil fuzzballs.