### PR TITLE
Evolving Mice event

### DIFF
--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -66,7 +66,7 @@
 	switch(vermin)
 		if(VERM_MICE)
 			spawn_types = list(/mob/living/simple_animal/mouse/event)
-			max_number = 12
+			max_number = 6
 			vermstring = "mice"
 		if(VERM_LIZARDS)
 			spawn_types = list(/mob/living/simple_animal/lizard)

--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -65,7 +65,7 @@
 	vermin = rand(0,2)
 	switch(vermin)
 		if(VERM_MICE)
-			spawn_types = list(/mob/living/simple_animal/mouse/gray, /mob/living/simple_animal/mouse/brown, /mob/living/simple_animal/mouse/white)
+			spawn_types = list(/mob/living/simple_animal/mouse/event)
 			max_number = 12
 			vermstring = "mice"
 		if(VERM_LIZARDS)

--- a/code/modules/mob/living/simple_animal/animals/mouse.dm
+++ b/code/modules/mob/living/simple_animal/animals/mouse.dm
@@ -157,7 +157,7 @@
 /mob/living/simple_animal/mouse/event/proc/rat()
 	visible_message("<span class='warning'>\The [src] suddenly evolves!</span>")
 	if(prob(99.5))
-		new /mob/living/simple_animal/hostile/rat(get_turf(src))
+		new /mob/living/simple_animal/hostile/rat/event(get_turf(src))
 		qdel(src)
 	else	
 		new /mob/living/simple_animal/hostile/chungus(get_turf(src))

--- a/code/modules/mob/living/simple_animal/animals/mouse.dm
+++ b/code/modules/mob/living/simple_animal/animals/mouse.dm
@@ -42,7 +42,8 @@
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat
 
 	var/body_color //brown, gray and white, leave blank for random
-
+	var/amount_grown = 0
+	
 /mob/living/simple_animal/mouse/Life()
 	. = ..()
 	if(!. || ai_inactive) return
@@ -135,3 +136,43 @@
 
 /mob/living/simple_animal/mouse/cannot_use_vents()
 	return
+
+	
+	
+	
+	
+
+//EVENT mice that evolve into rats because exctement.
+/mob/living/simple_animal/mouse/event
+	desc = "This one looks like it is growing huge!"
+	
+/mob/living/simple_animal/mouse/event/Life()
+	. = ..()
+	if(amount_grown >= 0)
+		amount_grown += rand(0,2)
+	if(amount_grown >= 100)
+		rat()
+		return
+
+/mob/living/simple_animal/mouse/event/proc/rat()
+	visible_message("<span class='warning'>\The [src] suddenly evolves!</span>")
+	if(prob(99.5))
+		new /mob/living/simple_animal/hostile/rat(get_turf(src))
+		qdel(src)
+	else	
+		new /mob/living/simple_animal/hostile/chungus(get_turf(src))
+		qdel(src)
+		
+
+	
+	
+	
+
+/mob/living/simple_animal/mouse/white/event
+
+
+/mob/living/simple_animal/mouse/gray/event
+
+
+/mob/living/simple_animal/mouse/brown/event
+

--- a/code/modules/mob/living/simple_animal/vore/chungus.dm
+++ b/code/modules/mob/living/simple_animal/vore/chungus.dm
@@ -16,6 +16,7 @@
 	melee_damage_lower = 5
 	melee_damage_upper = 15
 	grab_resist = 100
+	attack_sound = 'sound/weapons/bite.ogg'
 
 	speak_chance = 4
 	speak = list("Eenhhhhhhh...","What's up, doc?","Wabbit season?")

--- a/code/modules/mob/living/simple_animal/vore/rat.dm
+++ b/code/modules/mob/living/simple_animal/vore/rat.dm
@@ -158,3 +158,8 @@
 /mob/living/simple_animal/hostile/rat/death()
 	playsound(src, 'sound/effects/mouse_squeak_loud.ogg', 50, 1)
 	..()
+
+/mob/living/simple_animal/hostile/rat/event
+	maxHealth = 60
+	health = 60
+	vore_pounce_chance = 1

--- a/code/modules/mob/living/simple_animal/vore/rat.dm
+++ b/code/modules/mob/living/simple_animal/vore/rat.dm
@@ -16,6 +16,7 @@
 	melee_damage_lower = 5
 	melee_damage_upper = 15
 	grab_resist = 100
+	attack_sound = 'sound/weapons/bite.ogg'
 
 	speak_chance = 4
 	speak = list("Squeek!","SQUEEK!","Squeek?")


### PR DESCRIPTION
Upon station announcement of a mice infestation, the mice will now slowly grow into giant rats thanks to bluespace warp shenanigans.

Reminder that giant rats are immediately hostile, deal 5~15 damage, have 150 health, and are pretty damn hungry, so with that in mind, be careful, or try to kill the mice quickly!

Additional:
+Giant rats now have the bite sound effect when they attack.