### PR TITLE
This should remove Xeno-hybrids from whitelist

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -285,7 +285,7 @@
 
 	//primitive_form = "" //None for these guys
 
-	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED
+	spawn_flags = SPECIES_CAN_JOIN //| SPECIES_IS_WHITELISTED //CHOMPEDIT: REmoving whitelist for xenohybrids
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
 
 	blood_color = "#12ff12"


### PR DESCRIPTION
Reason for this: They are basically just reskinned humans with better darksight and slightly higher food consumption