### PR TITLE
Adding Minor Deathclaws for mining

### DIFF
--- a/code/modules/mob/living/simple_animal/vore/deathclaw.dm
+++ b/code/modules/mob/living/simple_animal/vore/deathclaw.dm
@@ -41,3 +41,29 @@
 	vore_min_size = RESIZE_SMALL
 	vore_pounce_chance = 0 // Beat them into crit before eating.
 	vore_icons = SA_ICON_LIVING
+
+//CHOMPEDIT Adding mining friendly dedclaws
+/mob/living/simple_animal/hostile/deathclaw/minor //or miner
+	name = "minor deathclaw"
+	desc = "Big! The size of two men! Claws as long as my hand! Ripped apart! Ripped apart!"
+	maxHealth = 150
+	health = 150
+	melee_damage_lower = 5
+	melee_damage_upper = 30
+
+//Activate Lootdrops
+/mob/living/simple_animal/hostile/deathclaw/minor/death()
+	..()
+	if(prob(80))
+		visible_message("<span class='notice'>\The [src] dropped some ore!</span>")
+		var/location = get_turf(src)
+		new /obj/item/weapon/ore/diamond(location)
+	if(prob(40))
+		visible_message("<span class='notice'>\The [src] dropped some ore!</span>")
+		var/location = get_turf(src)
+		new /obj/item/weapon/ore/uranium(location)
+	if(prob(1))
+		visible_message("<span class='notice'>\The [src] suddenly regenerates!</span>")
+		var/location = get_turf(src)
+		new /mob/living/simple_animal/hostile/deathclaw/minor(location)
+		qdel(src)


### PR DESCRIPTION
Minor deathclaws are weaker, both in hp and damage
They also have a high chance to drop diamonds on kill and even uranium!

HOWEVER be careful some of them might be special mutations that regenerate their lifebar just when you FINALLY removed the last sliver of health like some bad retro boss battle that thinks a wall of meat is a good boss.... wait didnt terraria literally do that?