### PR TITLE
Now logs where the mob died

### DIFF
--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -70,6 +70,7 @@
 
 	if(stat == DEAD)
 		return 0
+	var/location = get_turf(src) //CHOMPEDIT: since we use this so much lets define it here yknow
 	if(src.loc && istype(loc,/obj/belly)) deathmessage = "no message" //VOREStation Add - Prevents death messages from inside mobs
 	facing_dir = null
 


### PR DESCRIPTION
new var `location` that remembers where the mob died making on death spawn easier

usage example
oldmob/path/death()
    ..()
    new mob/path(location)