### PR TITLE
Vocal mimicry for synxes

### DIFF
--- a/code/modules/mob/living/simple_animal/animals/synx.dm
+++ b/code/modules/mob/living/simple_animal/animals/synx.dm
@@ -336,7 +336,7 @@ mob/living/simple_animal/synx/PunchTarget()
 		spawn(10)
 			src.say(pick(speak))
 	else 
-		src.custom_pain("YOU NEED TO HEAR THINGS FIRST, try using Ventcrawl to eevesdrop on nerds",30)
+		self_message("YOU NEED TO HEAR THINGS FIRST, try using Ventcrawl to eevesdrop on nerds")
 	spawn(20)
 		name = realname
 

--- a/code/modules/mob/living/simple_animal/animals/synx.dm
+++ b/code/modules/mob/living/simple_animal/animals/synx.dm
@@ -25,7 +25,7 @@
 	maxHealth = 150
 	health = 150
 	turns_per_move = 5 //Should just affect how often it wanders, subject to change.
-	speed = -2 //Re enabled custom speed
+	speed = 2 //Re enabled custom speed
 	see_in_dark = 6
 	stop_when_pulled = 0
 	armor = list(			// will be determined
@@ -299,13 +299,13 @@ mob/living/simple_animal/synx/PunchTarget()
 		status_flags &= ~HIDING
 		reset_plane_and_layer()
 		to_chat(src,"<span class='notice'>You have stopped hiding.</span>")
-		speed = -3
+		speed = 2
 	else
 		status_flags |= HIDING
 		layer = HIDING_LAYER //Just above cables with their 2.44
 		plane = OBJ_PLANE
 		to_chat(src,"<span class='notice'>You are now hiding.</span>")
-		speed = 2
+		speed = 4
 
 /mob/living/simple_animal/retaliate/synx/proc/disguise()
 	set name = "Toggle Form"

--- a/code/modules/mob/living/simple_animal/animals/synx.dm
+++ b/code/modules/mob/living/simple_animal/animals/synx.dm
@@ -10,12 +10,14 @@
 	icon_dead = "synx_dead"
 
 	//VAR$ SETUP
+	var/realname = null
 	var/poison_per_bite = 5
 	var/poison_chance = 99.666
 	var/poison_type = "synxchem"//inaprovalin, but evil
 	var/transformed_state = "synx_transformed"
 	var/transformed = FALSE
 	var/memorysize = 50 //Var for how many messages synxes remember if they know speechcode
+	var/list/voices = list()
 
 	faction = "Synx"
 	intelligence_level = SA_ANIMAL
@@ -113,11 +115,13 @@
 	*/
 
 /mob/living/simple_animal/retaliate/synx/New()
-    ..()
-    verbs |= /mob/living/proc/ventcrawl
-    verbs |= /mob/living/simple_animal/proc/contort
-    verbs +=  /mob/living/simple_animal/retaliate/synx/proc/disguise
-    verbs +=  /mob/living/simple_animal/retaliate/synx/proc/honk
+	..()
+	verbs |= /mob/living/proc/ventcrawl
+	verbs |= /mob/living/simple_animal/proc/contort
+	verbs += /mob/living/simple_animal/retaliate/synx/proc/disguise
+	verbs += /mob/living/simple_animal/retaliate/synx/proc/honk
+	verbs += /mob/living/simple_animal/retaliate/synx/proc/randomspeech
+	realname = name
 
 mob/living/simple_animal/synx/PunchTarget()
 	if(!Adjacent(target_mob))
@@ -264,7 +268,21 @@ mob/living/simple_animal/synx/PunchTarget()
 					if(prob(poison_chance))
 						to_chat(L, "<span class='warning'>You feel a strange substance on you.</span>")
 						L.reagents.add_reagent(poison_type, poison_per_bite)
-						
+
+/mob/living/simple_animal/retaliate/synx/hear_say(message,speaker)
+	. = ..()
+	if(!message)    return
+	speak += message
+	voice += speaker
+	if(voices.len>=memorysize)
+		voices -= (pick(voices))//making the list more dynamic
+	if(speak.len>=memorysize)
+		speak -= (pick(speak))//making the list more dynamic
+	if(resting)
+		resting = !resting
+	if(message=="Honk!")
+		bikehorn()
+
 //////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////// POWERS!!!! /////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////
@@ -309,6 +327,16 @@ mob/living/simple_animal/synx/PunchTarget()
 	transformed = !transformed
 	update_icons()
 
+/mob/living/simple_animal/retaliate/synx/proc/randomspeech()
+	set name = "speak"
+	set desc = "Takes a sentence you heard and says it"
+	set category = "Abilities"
+	name = pick(voices)
+	if(speak)
+		spawn(10)
+			src.say(pick(speak))
+	spawn(20)
+		name = realname
 
 ////////////////////////////////////////
 ////////////////PET VERSION/////////////
@@ -339,18 +367,6 @@ mob/living/simple_animal/synx/PunchTarget()
 /mob/living/simple_animal/retaliate/synx/pet
 	speak_chance = 2.0666
 	speak = list()
-
-//PET speechcode, simplistic but more than enough for the PET
-/mob/living/simple_animal/retaliate/synx/pet/hear_say(message)
-	. = ..()
-	if(!message)    return
-	speak += message
-	if(speak.len>=memorysize)
-		speak -= (pick(speak))//making the list more dynamic
-	if(resting)
-		resting = !resting
-	if(message=="Honk!")
-		bikehorn()
 
 //HONKMOTHER Code.
 /mob/living/simple_animal/retaliate/synx/proc/honk()

--- a/code/modules/mob/living/simple_animal/animals/synx.dm
+++ b/code/modules/mob/living/simple_animal/animals/synx.dm
@@ -331,10 +331,12 @@ mob/living/simple_animal/synx/PunchTarget()
 	set name = "speak"
 	set desc = "Takes a sentence you heard and says it"
 	set category = "Abilities"
-	name = pick(voices)
-	if(speak)
+	if(speak && voices)
+		name = pick(voices)
 		spawn(10)
 			src.say(pick(speak))
+	else 
+		M.custom_pain("YOU NEED TO HEAR THINGS FIRST, try using Ventcrawl to eevesdrop on nerds",30)
 	spawn(20)
 		name = realname
 

--- a/code/modules/mob/living/simple_animal/animals/synx.dm
+++ b/code/modules/mob/living/simple_animal/animals/synx.dm
@@ -273,7 +273,7 @@ mob/living/simple_animal/synx/PunchTarget()
 	. = ..()
 	if(!message)    return
 	speak += message
-	voice += speaker
+	voices += speaker
 	if(voices.len>=memorysize)
 		voices -= (pick(voices))//making the list more dynamic
 	if(speak.len>=memorysize)

--- a/code/modules/mob/living/simple_animal/animals/synx.dm
+++ b/code/modules/mob/living/simple_animal/animals/synx.dm
@@ -336,7 +336,7 @@ mob/living/simple_animal/synx/PunchTarget()
 		spawn(10)
 			src.say(pick(speak))
 	else 
-		M.custom_pain("YOU NEED TO HEAR THINGS FIRST, try using Ventcrawl to eevesdrop on nerds",30)
+		src.custom_pain("YOU NEED TO HEAR THINGS FIRST, try using Ventcrawl to eevesdrop on nerds",30)
 	spawn(20)
 		name = realname
 

--- a/code/modules/mob/living/simple_animal/animals/synx.dm
+++ b/code/modules/mob/living/simple_animal/animals/synx.dm
@@ -336,7 +336,7 @@ mob/living/simple_animal/synx/PunchTarget()
 		spawn(10)
 			src.say(pick(speak))
 	else 
-		self_message("YOU NEED TO HEAR THINGS FIRST, try using Ventcrawl to eevesdrop on nerds")
+		usr << "<span class='warning'>YOU NEED TO HEAR THINGS FIRST, try using Ventcrawl to eevesdrop on nerds</span>"
 	spawn(20)
 		name = realname
 


### PR DESCRIPTION
trying to write a vocal mimicry system.

this might be very spagheti and attempts to integrate the existing pet mimicry into the base synx to try and make use of the mob speak list as a storage for random sentences to choose from as well as adding the `voices` list to store names of people, yes this does include yourself if you play as a synx and use say instead of speak, no you should not be using say as a synx in the first place.

Might populate the say for synxes and voices for synxes with random voices and sentences so they dont start at 0