### PR TITLE
MAking Drone reboot text dynamic

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -319,7 +319,7 @@ var/list/mob_hat_cache = list()
 /mob/living/silicon/robot/drone/proc/question(var/client/C)
 	spawn(0)
 		if(!C || jobban_isbanned(C,"Cyborg"))	return
-		var/response = alert(C, "Someone is attempting to reboot a maintenance drone. Would you like to play as one?", "Maintenance drone reboot", "Yes", "No", "Never for this round")
+		var/response = alert(C, text("Someone is attempting to reboot a []. Would you like to play as one?",src), text("[] reboot",src), "Yes", "No", "Never for this round")
 		if(!C || ckey)
 			return
 		if(response == "Yes")


### PR DESCRIPTION
Basing this on the auth formatting for shutle override
`text("Would you like to (un)authorize a shortened launch time? [] authorization\s are still needed. Use abort to cancel all authorizations.", src.auth_need - src.authorized.len)`