### PR TITLE
Drone Fab QOL changes to naming and backup fab

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -42,7 +42,7 @@
 	/mob/living/silicon/robot/drone/construction,
 	/mob/living/silicon/robot/drone,)
 
-/obj/machinery/drone_fabricator/proc/create_drone() //Proc where we inject our randomizer code
+/obj/machinery/drone_fabricator/random/create_drone() //Proc where we inject our randomizer code
 	drone_type = pick(dronetypes)
 	..()
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -5,7 +5,7 @@
 	return drones
 
 /obj/machinery/drone_fabricator
-	name = "drone fabricator"
+	name = "Maintenance drone fabricator"
 	desc = "A large automated factory for producing maintenance drones."
 	appearance_flags = 0
 
@@ -15,7 +15,7 @@
 	idle_power_usage = 20
 	active_power_usage = 5000
 
-	var/fabricator_tag = "Upper Level"
+	var/fabricator_tag = "Engineering Dronestorage, Maintenance"
 	var/drone_progress = 0
 	var/produce_drones = 2
 	var/time_last_drone = 500
@@ -25,14 +25,26 @@
 	icon_state = "drone_fab_idle"
 
 /obj/machinery/drone_fabricator/derelict
-	name = "construction drone fabricator"
-	fabricator_tag = "Upper Level Construction"
+	name = "Construction drone fabricator"
+	fabricator_tag = "Engineering Dronestorage, Construction"
 	drone_type = /mob/living/silicon/robot/drone/construction
 
 /obj/machinery/drone_fabricator/mining
-	name = "mining drone fabricator"
-	fabricator_tag = "Upper Level Mining"
+	name = "Mining drone fabricator"
+	fabricator_tag = "Outpost Mining"
 	drone_type = /mob/living/silicon/robot/drone/mining
+
+/obj/machinery/drone_fabricator/random
+	name = "Backup drone fabricator"
+	fabricator_tag = "Backup Drone Fabricator"
+	drone_type = null //we start with no type, we take from the list below
+	var/list/dronetypes = list(/mob/living/silicon/robot/drone/mining,
+	/mob/living/silicon/robot/drone/construction,
+	/mob/living/silicon/robot/drone,)
+
+/obj/machinery/drone_fabricator/proc/create_drone() //Proc where we inject our randomizer code
+	drone_type = pick(dronetypes)
+	..()
 
 /obj/machinery/drone_fabricator/New()
 	..()


### PR DESCRIPTION
Unified naming of all tags to be more informative, no more "upper level" precise naming of where you spawn and what for.
Ex: "Outpost Mining" "Engineering Dronestorage, Construction"

Unified naming across fabricators to be "Drone type Fabricator" so that maintenance drone fabricators arent just called "Drone fabricators"

Added a new fabricator type which will be ~~violently~~ lovingly, forced into the AI room, it picks a random drone type from the available types and produces it, this is basically the "station has no power" selection.