### PR TITLE
Mining Drone control access override

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_console.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_console.dm
@@ -17,7 +17,7 @@
 	for(var/obj/machinery/drone_fabricator/fab in oview(3,src))
 		dronefab = fab
 	if(istype(dronefab, /obj/machinery/drone_fabricator/mining))
-		req_access = = list(access_mining)
+		req_access = list(access_mining)
 
 /obj/machinery/computer/drone_control/attack_ai(var/mob/user as mob)
 	return src.attack_hand(user)

--- a/code/modules/mob/living/silicon/robot/drone/drone_console.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_console.dm
@@ -1,5 +1,5 @@
 /obj/machinery/computer/drone_control
-	name = "Maintenance Drone Control"
+	name = "Drone Control"
 	desc = "Used to monitor the station's drone population and the assembler that services them."
 	icon_keyboard = "power_key"
 	icon_screen = "generic" //VOREStation Edit
@@ -10,6 +10,14 @@
 	var/drone_call_area = "Engineering"
 	//Used to enable or disable drone fabrication.
 	var/obj/machinery/drone_fabricator/dronefab
+
+
+/obj/machinery/computer/drone_control/New()
+	..()
+	for(var/obj/machinery/drone_fabricator/fab in oview(3,src))
+		dronefab = fab
+	if(istype(dronefab, /obj/machinery/drone_fabricator/mining))
+		req_access = = list(access_mining)
 
 /obj/machinery/computer/drone_control/attack_ai(var/mob/user as mob)
 	return src.attack_hand(user)


### PR DESCRIPTION
Drone Controllers should now sync on creation with the nearest fabricator

Additionally IF a mining fabricator is detected access should automatically be given to mining instead of engineering.

Also they are not called "Drone Controllers" no longer "Maintenance Drone Controllers"