### PR TITLE
Light replacer yogstation-TG port

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -55,6 +55,11 @@
 	var/failmsg = ""
 	var/charge = 0
 
+	// Eating used bulbs gives us bulb shards
+	var/bulb_shards = 0
+	// when we get this many shards, we get a free bulb.
+	var/shards_required = 4
+
 /obj/item/device/lightreplacer/New()
 	failmsg = "The [name]'s refill light blinks red."
 	..()
@@ -77,17 +82,54 @@
 			to_chat(user, "<span class='warning'>You need one sheet of glass to replace lights.</span>")
 
 	if(istype(W, /obj/item/weapon/light))
+		var/new_bulbs = 0
 		var/obj/item/weapon/light/L = W
 		if(L.status == 0) // LIGHT OKAY
 			if(uses < max_uses)
-				add_uses(1)
-				to_chat(user, "You insert \the [L.name] into \the [src.name]. You have [uses] light\s remaining.")
-				user.drop_item()
+				if(!user.unEquip(W))
+					return
+				AddUses(1)
 				qdel(L)
-				return
 		else
-			to_chat(user, "You need a working light.")
+			if(!user.unEquip(W))
+				return
+			new_bulbs += AddShards(1)
+			qdel(L)
+		if(new_bulbs != 0)
+			playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
+		to_chat(user, "<span class='notice'>You insert the [L.name] into the [src.name]. " + status_string() + "</span>")
+		return
+
+	if(istype(W, /obj/item/weapon/storage))
+		var/obj/item/weapon/storage/S = W
+		var/found_lightbulbs = FALSE
+		var/replaced_something = TRUE
+
+		for(var/obj/item/I in S.contents)
+			if(istype(I,/obj/item/weapon/light))
+				var/obj/item/weapon/light/L = I
+				found_lightbulbs = TRUE
+				if(src.uses >= max_uses)
+					break
+				if(L.status == LIGHT_OK)
+					replaced_something = TRUE
+					AddUses(1)
+					qdel(L)
+
+				else if(L.status == LIGHT_BROKEN || L.status == LIGHT_BURNED)
+					replaced_something = TRUE
+					AddShards(1)
+					qdel(L)
+
+		if(!found_lightbulbs)
+			to_chat(user, "<span class='warning'>\The [S] contains no bulbs.</span>")
 			return
+
+		if(!replaced_something && src.uses == max_uses)
+			to_chat(user, "<span class='warning'>\The [src] is full!</span>")
+			return
+
+		to_chat(user, "<span class='notice'>You fill \the [src] with lights from \the [S]. " + status_string() + "</span>")
 
 /obj/item/device/lightreplacer/attack_self(mob/user)
 	/* // This would probably be a bit OP. If you want it though, uncomment the code.
@@ -114,6 +156,15 @@
 /obj/item/device/lightreplacer/proc/add_uses(var/amount = 1)
 	uses = min(max(uses + amount, 0), max_uses)
 
+
+/obj/item/device/lightreplacer/proc/AddShards(amount = 1)
+	bulb_shards += amount
+	var/new_bulbs = round(bulb_shards / shards_required)
+	if(new_bulbs > 0)
+		AddUses(new_bulbs)
+	bulb_shards = bulb_shards % shards_required
+	return new_bulbs
+
 /obj/item/device/lightreplacer/proc/Charge(var/mob/user, var/amount = 1)
 	charge += amount
 	if(charge > 6)
@@ -128,17 +179,10 @@
 			U << "<span class='notice'>You replace the [target.fitting] with the [src].</span>"
 
 			if(target.status != LIGHT_EMPTY)
-
-				var/obj/item/weapon/light/L1 = new target.light_type(target.loc)
-				L1.status = target.status
-				L1.rigged = target.rigged
-				L1.brightness_range = target.brightness_range
-				L1.brightness_power = target.brightness_power
-				L1.brightness_color = target.brightness_color
-				L1.switchcount = target.switchcount
-				target.switchcount = 0
-				L1.update()
-
+				var/new_bulbs = AddShards(1)
+				if(new_bulbs != 0)
+					to_chat(U, "<span class='notice'>\The [src] has fabricated a new bulb from the broken bulbs it has stored. It now has [uses] uses.</span>")
+					playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
 				target.status = LIGHT_EMPTY
 				target.update()
 

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -88,7 +88,7 @@
 			if(uses < max_uses)
 				if(!user.unEquip(W))
 					return
-				AddUses(1)
+				add_uses(1)
 				qdel(L)
 		else
 			if(!user.unEquip(W))
@@ -97,7 +97,7 @@
 			qdel(L)
 		if(new_bulbs != 0)
 			playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
-		to_chat(user, "<span class='notice'>You insert the [L.name] into the [src.name]. " + status_string() + "</span>")
+		to_chat(user, "You insert \the [L.name] into \the [src.name]. You have [uses] light\s remaining.")
 		return
 
 	if(istype(W, /obj/item/weapon/storage))
@@ -113,7 +113,7 @@
 					break
 				if(L.status == LIGHT_OK)
 					replaced_something = TRUE
-					AddUses(1)
+					add_uses(1)
 					qdel(L)
 
 				else if(L.status == LIGHT_BROKEN || L.status == LIGHT_BURNED)
@@ -129,7 +129,7 @@
 			to_chat(user, "<span class='warning'>\The [src] is full!</span>")
 			return
 
-		to_chat(user, "<span class='notice'>You fill \the [src] with lights from \the [S]. " + status_string() + "</span>")
+		to_chat(user, "<span class='notice'>You fill \the [src] with lights from \the [S].</span>")
 
 /obj/item/device/lightreplacer/attack_self(mob/user)
 	/* // This would probably be a bit OP. If you want it though, uncomment the code.
@@ -161,7 +161,7 @@
 	bulb_shards += amount
 	var/new_bulbs = round(bulb_shards / shards_required)
 	if(new_bulbs > 0)
-		AddUses(new_bulbs)
+		add_uses(new_bulbs)
 	bulb_shards = bulb_shards % shards_required
 	return new_bulbs
 


### PR DESCRIPTION
Ever hate it how your light replacer replaces lights but just dumps trash on the floor? Hate how all that valuable broken glass is getting launched into space? Fear no more!
With a feature ported straight from yogstation, the light replacer now has additional functionality!
-Light replacer now eats broken lights instead of dropping them
-Every 4 broken lights eaten refills the light replacer with 1 new bulb
-You can now also use a box of lights on the light replacer to refill it (the old method of using the light replacer on the box still works)