### PR TITLE
Disable PDA Contamination

### DIFF
--- a/code/modules/vore/eating/contaminate_vr.dm
+++ b/code/modules/vore/eating/contaminate_vr.dm
@@ -91,6 +91,9 @@ var/image/gurgled_overlay = image('icons/effects/sludgeoverlay_vr.dmi')
 		return
 	..()
 
+/obj/item/device/pda/gurgle_contaminate(var/atom/movable/item_storage = null)
+	return FALSE
+
 //////////////
 // Special handling of gurgle_contaminate
 //////////////


### PR DESCRIPTION
No more meta-gaming that people must have been ate/churned away with their PDA showing as (whatever) (name) (job). Ported from VoreStation, yay. Linky-linky: https://github.com/VOREStation/VOREStation/pull/4562