### PR TITLE
KHI purge

### DIFF
--- a/code/modules/busy_space_vr/organizations.dm
+++ b/code/modules/busy_space_vr/organizations.dm
@@ -437,6 +437,7 @@
 						"the SolGov embassy in Vilous"
 						)// autogen will add a lot of other places as well.
 
+/* //Removed ships in Virgo space because we're not in Virgo space. Perhaps revert back to Polaris later since we're in Vir.
 /datum/lore/organization/gov/sifgov // Overrides Polaris stuff
 	name = "Virgo-Erigone Governmental Authority"
 	short_name = ""
@@ -468,6 +469,7 @@
 						"a telecommunications satellite near Virgo-3B",
 						"a telecommunications satellite near Virgo-Prime"
 						)
+*/
 
 /* // Waiting for lore to be updated.
 /datum/lore/organization/gov/federation
@@ -677,6 +679,7 @@
 							"... wait, why am I even telling you this? Just let me pass",
 							"stop asking questions")
 
+/* //KHI does not exist in our canon.
 /datum/lore/organization/gov/kitsuhana
 	name = "Kitsuhana Heavy Industries"
 	short_name = "Kitsuhana"
@@ -730,6 +733,7 @@
 						"a Kitsuhana ringworld in Lund VI",
 						"a Kitsuhana ringworld in Dais IX",
 						"a Kitsuhana ringworld in Leibert II-b")
+*/
 
 /datum/lore/organization/gov/ares
 	name = "Ares Confederation"
@@ -788,6 +792,7 @@
 						"a settlement needing our help",
 						"Forward Base Sigma-Alpha in ArCon space")
 
+/* //Also commiting this out because we don't have space elves.
 /datum/lore/organization/gov/imperial
 	name = "Auream Imperium"
 	short_name = "Imperial"
@@ -884,3 +889,4 @@
 							"near Cor Galaxia",
 							"Segmentum Obscurum", // Basically their home territory, where our telescopes can't see. They prefer to keep it that way. They call it something else internally.
 							)
+*/

--- a/code/modules/client/preference_setup/loadout/loadout_uniform_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform_vr.dm
@@ -7,30 +7,30 @@
 	display_name = "pt uniform, planetside sec"
 	path = /obj/item/clothing/under/pt/sifguard
 
-//KHI Uniforms
-/datum/gear/uniform/job_khi/cmd
-	display_name = "khi uniform, cmd"
-	path = /obj/item/clothing/under/rank/khi/cmd
+//GE Uniforms
+/datum/gear/uniform/job_ge/cmd
+	display_name = "ge uniform, cmd"
+	path = /obj/item/clothing/under/rank/ge/cmd
 	allowed_roles = list("Head of Security","Colony Director","Head of Personnel","Chief Engineer","Research Director","Chief Medical Officer")
 
-/datum/gear/uniform/job_khi/sec
-	display_name = "khi uniform, sec"
-	path = /obj/item/clothing/under/rank/khi/sec
+/datum/gear/uniform/job_ge/sec
+	display_name = "ge uniform, sec"
+	path = /obj/item/clothing/under/rank/ge/sec
 	allowed_roles = list("Head of Security", "Warden", "Detective", "Security Officer")
 
-/datum/gear/uniform/job_khi/med
-	display_name = "khi uniform, med"
-	path = /obj/item/clothing/under/rank/khi/med
+/datum/gear/uniform/job_ge/med
+	display_name = "ge uniform, med"
+	path = /obj/item/clothing/under/rank/ge/med
 	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist")
 
-/datum/gear/uniform/job_khi/eng
-	display_name = "khi uniform, eng"
-	path = /obj/item/clothing/under/rank/khi/eng
+/datum/gear/uniform/job_ge/eng
+	display_name = "ge uniform, eng"
+	path = /obj/item/clothing/under/rank/ge/eng
 	allowed_roles = list("Chief Engineer","Atmospheric Technician","Station Engineer")
 
-/datum/gear/uniform/job_khi/sci
-	display_name = "khi uniform, sci"
-	path = /obj/item/clothing/under/rank/khi/sci
+/datum/gear/uniform/job_ge/sci
+	display_name = "ge uniform, sci"
+	path = /obj/item/clothing/under/rank/ge/sci
 	allowed_roles = list("Research Director","Scientist", "Roboticist", "Xenobiologist")
 
 //Federation jackets

--- a/code/modules/clothing/glasses/hud_vr.dm
+++ b/code/modules/clothing/glasses/hud_vr.dm
@@ -1,7 +1,7 @@
 /obj/item/clothing/glasses/omnihud
 	name = "\improper AR glasses"
-	desc = "The KHI-62 AR Glasses are a design from Kitsuhana Heavy Industries. These are a cheap export version \
-	for Nanotrasen. Probably not as complete as KHI could make them, but more readily available for NT."
+	desc = "The WT-62 AR Glasses are a design from Ward-Takahashi GMB. These are a cheap export version \
+	for Nanotrasen. Definitely not as complete as WT could make them, but more readily available for NT."
 	origin_tech = list(TECH_MAGNET = 3, TECH_BIO = 3)
 	var/obj/item/clothing/glasses/hud/omni/hud = null
 	var/mode = "civ"
@@ -67,7 +67,7 @@
 
 /obj/item/clothing/glasses/omnihud/med
 	name = "\improper AR-M glasses"
-	desc = "The KHI-62-M AR glasses are a design from Kitsuhana Heavy Industries. \
+	desc = "The WT-62-M AR glasses are a design from Ward-Takahashi GMB. \
 	These have been upgraded with medical records access and virus database integration."
 	mode = "med"
 	action_button_name = "AR Console (Crew Monitor)"
@@ -81,7 +81,7 @@
 
 /obj/item/clothing/glasses/omnihud/sec
 	name = "\improper AR-S glasses"
-	desc = "The KHI-62-S AR glasses are a design from Kitsuhana Heavy Industries. \
+	desc = "The WT-62-S AR glasses are a design from Ward-Takahashi GMB. \
 	These have been upgraded with security records integration and flash protection."
 	mode = "sec"
 	flash_protection = FLASH_PROTECTION_MAJOR
@@ -96,7 +96,7 @@
 
 /obj/item/clothing/glasses/omnihud/eng
 	name = "\improper AR-E glasses"
-	desc = "The KHI-62-E AR glasses are a design from Kitsuhana Heavy Industries. \
+	desc = "The WT-62-E AR glasses are a design from Ward-Takahashi GMB. \
 	These have been upgraded with advanced electrochromic lenses to protect your eyes during welding."
 	mode = "eng"
 	flash_protection = FLASH_PROTECTION_MAJOR
@@ -110,7 +110,7 @@
 
 /obj/item/clothing/glasses/omnihud/rnd
 	name = "\improper AR-R glasses"
-	desc = "The KHI-62-R AR glasses are a design from Kitsuhana Heavy Industries. \
+	desc = "The WT-62-R AR glasses are a design from Ward-Takahashi GMB. \
 	These have been ... modified ... to fit into a different frame."
 	mode = "sci"
 	icon = 'icons/obj/clothing/glasses.dmi'
@@ -156,7 +156,7 @@
 
 /obj/item/clothing/glasses/omnihud/all
 	name = "\improper AR-B glasses"
-	desc = "The KHI-62-B AR glasses are a design from Kitsuhana Heavy Industries. \
+	desc = "The WT-62-B AR glasses are a design from Ward-Takahashi GMB. \
 	These have been upgraded with every feature the lesser models have. Now we're talkin'."
 	mode = "best"
 	flash_protection = FLASH_PROTECTION_MAJOR

--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -15,7 +15,7 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 //Nanotech Implant Foundation
 /obj/item/device/nif
 	name = "nanite implant framework"
-	desc = "A somewhat diminished knockoff of a Kitsuhana nano working surface, in a box. Can print new \
+	desc = "A somewhat diminished knockoff of a Vey-Med nano working surface, in a box. Can print new \
 	implants inside living hosts on the fly based on software uploads. Must be surgically \
 	implanted in the head to work. May eventually wear out and break."
 
@@ -33,7 +33,7 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 	var/tmp/list/nifsofts_life = list()			// Ones that want to be talked to on life()
 	var/owner									// Owner character name
 	var/examine_msg								//Message shown on examine.
-	
+
 	var/tmp/vision_flags = 0		// Flags implants set for faster lookups
 	var/tmp/health_flags = 0
 	var/tmp/combat_flags = 0
@@ -72,9 +72,9 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 	//Put loaded data here if we loaded any
 	save_data = islist(load_data) ? load_data.Copy() : list()
 	var/saved_examine_msg = save_data["examine_msg"]
-	
+
 	//If it's an empty string, they want it blank. If null, it's never been saved, give default.
-	if(isnull(saved_examine_msg)) 
+	if(isnull(saved_examine_msg))
 		saved_examine_msg = "There's a certain spark to their eyes."
 	examine_msg = saved_examine_msg
 
@@ -114,7 +114,7 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 	var/obj/item/organ/brain = H.internal_organs_by_name[O_BRAIN]
 	if(istype(brain))
 		should_be_in = brain.parent_organ
-	
+
 	if(istype(H) && !H.nif && H.species && (loc == H.get_organ(should_be_in)))
 		if(!bioadap && (H.species.flags & NO_SCAN)) //NO_SCAN is the default 'too complicated' flag
 			return FALSE
@@ -135,7 +135,7 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 		var/obj/item/organ/brain = H.internal_organs_by_name[O_BRAIN]
 		if(istype(brain))
 			should_be_in = brain.parent_organ
-		
+
 		parent = H.get_organ(should_be_in)
 		//Ok, nevermind then!
 		if(!istype(parent))
@@ -559,9 +559,9 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 	durability = 10
 
 /obj/item/device/nif/authentic
-	name = "\improper Kitsuhana NIF"
-	desc = "An actual Kitsuhana working surface, in a box. From a society slightly less afraid \
-	of self-replicating nanotechnology. Basically just a high-endurance NIF."
+	name = "\improper Vey-Med NIF"
+	desc = "An actual Vey-Med working surface, in a box. They are said to have been stolen \
+	from an internal company shipment. Basically just a high-endurance NIF."
 	durability = 1000
 
 /obj/item/device/nif/bioadap

--- a/code/modules/organs/robolimbs_vr.dm
+++ b/code/modules/organs/robolimbs_vr.dm
@@ -5,8 +5,8 @@
 
 //////////////// For-specific-character fluff ones /////////////////
 // arokha : Aronai Kadigan
-/datum/robolimb/kitsuhana
-	company = "Kitsuhana"
+/datum/robolimb/dsi_aronai
+	company = "DSI - Aronai"
 	desc = "This limb seems rather vulpine and fuzzy, with realistic-feeling flesh."
 	icon = 'icons/mob/human_races/cyberlimbs/_fluff_vr/aronai.dmi'
 	blood_color = "#5dd4fc"
@@ -16,8 +16,8 @@
 	suggested_species = "Tajara"
 	whitelisted_to = list("arokha")
 
-/obj/item/weapon/disk/limb/kitsuhana
-	company = "Kitsuhana"
+/obj/item/weapon/disk/limb/dsi_aronai
+	company = "DSI - Aronai"
 
 // silencedmp5a5 : Serdykov Antoz
 /datum/robolimb/white_kryten

--- a/code/modules/projectiles/guns/energy/netgun_vr.dm
+++ b/code/modules/projectiles/guns/energy/netgun_vr.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/gun/energy/netgun
-	name = "\improper KHI \"Hunter\" capture gun"
-	desc = "A Kitsuhana-designed 'non-lethal capture device' stunner and energy net launcher, \
+	name = "\improper HI \"Hunter\" capture gun"
+	desc = "A Hesphaistos Industries-designed 'non-lethal capture device' stunner and energy net launcher, \
 			for when you want criminals to stop acting like they're on a 20th century British comedy sketch show."
 	icon = 'icons/obj/gun_vr.dmi'
 	icon_state = "hunter"

--- a/code/modules/resleeving/documents.dm
+++ b/code/modules/resleeving/documents.dm
@@ -27,7 +27,7 @@
 				<br>
 				<h1><a name="Foreword">Foreword: A Licensed Technology</a></h1>
 				This message must remain attached to all documentation regarding Nanotrasen Resleeving Technology.<br>
-				All Nanotrasen Resleeving Technology (NRT) is licensed to Nanotrasen by Kitsuhana Heavy Industries. It should only be used in the ways set forth in this guide.
+				All Nanotrasen Resleeving Technology (NRT) is licensed to Nanotrasen by Vey-Med. It should only be used in the ways set forth in this guide.
 				Special consideration to the moral and ethical use of this technology should be undertaken before applying it in the field. Make sure you understand the technology fully before using the machinery.<br>
 				<a href="#Contents">Contents</a>
 

--- a/code/modules/resleeving/implant.dm
+++ b/code/modules/resleeving/implant.dm
@@ -15,7 +15,7 @@
 <b>Implant Specifications:</b><BR>
 <b>Name:</b> [using_map.company_name] Employee Backup Implant<BR>
 <b>Life:</b> ~8 hours.<BR>
-<b>Important Notes:</b> Implant is life-limited due to KHI licensing restrictions. Dissolves into harmless biomaterial after around ~8 hours, the typical work shift.<BR>
+<b>Important Notes:</b> Implant is life-limited due to VM licensing restrictions. Dissolves into harmless biomaterial after around ~8 hours, the typical work shift.<BR>
 <HR>
 <b>Implant Details:</b><BR>
 <b>Function:</b> Contains a small swarm of nanobots that perform neuron scanning to create mind-backups.<BR>
@@ -41,7 +41,7 @@
 //New, modern implanter instead of old style implanter.
 /obj/item/weapon/backup_implanter
 	name = "backup implanter"
-	desc = "After discovering that Nanotrasen was just re-using the same implanters over and over again on organics, leading to cross-contamination, Kitsuhana Heavy industries designed this self-cleaning model. Holds four backup implants at a time."
+	desc = "After discovering that Nanotrasen was just re-using the same implanters over and over again on organics, leading to cross-contamination, Vey-Med designed this self-cleaning model. Holds four backup implants at a time."
 	icon = 'icons/obj/device_alt.dmi'
 	icon_state = "bimplant"
 	item_state = "syringe_0"
@@ -152,5 +152,5 @@
 
 //Purely for fluff
 /obj/item/weapon/implant/backup/full
-	name = "khi backup implant"
-	desc = "A normal KHI wireless cortical stack with neutrino and QE transmission for constant-stream consciousness upload."
+	name = "vm backup implant"
+	desc = "A normal VM wireless cortical stack with neutrino and QE transmission for constant-stream consciousness upload."

--- a/code/modules/resleeving/sleevecard.dm
+++ b/code/modules/resleeving/sleevecard.dm
@@ -3,7 +3,7 @@
 
 /obj/item/device/sleevecard
 	name = "sleevecard"
-	desc = "This KHI-upgraded pAI module has enough capacity to run a whole mind of human-level intelligence."
+	desc = "This VM-upgraded pAI module has enough capacity to run a whole mind of human-level intelligence."
 
 	icon = 'icons/obj/pda.dmi'
 	icon_state = "pai"

--- a/code/modules/vore/fluffstuff/custom_clothes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_clothes_vr.dm
@@ -799,7 +799,7 @@
 			H.update_inv_head()
 
 /obj/item/weapon/rig/light/hacker/fluff/aronai
-	name = "KHI-99-AAR suit module"
+	name = "VM-99-AAR suit module"
 	suit_type = "nano"
 	desc = "A thin collapsable spacesuit for synths from Kitsuhana Heavy Industries."
 	airtight = 1 //Not because it should be airtight but because suit coolers don't work w/o it.
@@ -892,8 +892,8 @@
 	desc = "ROW ROW, FIGHT THE POWER."
 	flash_prot = 1 //Why not.
 
-//Kitsuhana Uniforms
-/obj/item/clothing/under/rank/khi
+//Gilthari Uniforms
+/obj/item/clothing/under/rank/ge
 	name = "Delete Me"
 	desc = "Why did you spawn this one? Dork."
 	sensor_mode = 3
@@ -904,49 +904,49 @@
 	icon_override = 'icons/vore/custom_clothes_vr.dmi'
 	item_state = ""
 
-/obj/item/clothing/under/rank/khi/cmd //Command version
-	name = "KHI command suit"
-	desc = "Kitsuhana Heavy Industries uniform. An extra-comfortable command one, at that. I guess if you DON'T want anarchy for some reason."
+/obj/item/clothing/under/rank/ge/cmd //Command version
+	name = "GE command suit"
+	desc = "Gilthari Exports uniform. An extra-comfortable command one, at that."
 	icon_state = "khi_uniform_cmd_i"
 	item_state = "khi_uniform_cmd"
 	worn_state = "khi_uniform_cmd"
 	armor = list(melee = 5, bullet = 10, laser = 10, energy = 0, bomb = 0, bio = 0, rad = 0)
 
-/obj/item/clothing/under/rank/khi/sec //Security version
-	name = "KHI security suit"
-	desc = "Kitsuhana Heavy Industries uniform. This one has angry red security stripes. Keepin' the peace in style."
+/obj/item/clothing/under/rank/ge/sec //Security version
+	name = "GE security suit"
+	desc = "Gilthari Exports uniform. This one has angry red security stripes. Keepin' the peace in style."
 	icon_state = "khi_uniform_sec_i"
 	item_state = "khi_uniform_sec"
 	worn_state = "khi_uniform_sec"
 	armor = list(melee = 10, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 
-/obj/item/clothing/under/rank/khi/med //Medical version
-	name = "KHI medical suit"
-	desc = "Kitsuhana Heavy Industries uniform. The medical version. Why not just get a new body, anyway?"
+/obj/item/clothing/under/rank/ge/med //Medical version
+	name = "GE medical suit"
+	desc = "Gilthari Exports uniform. The medical version. Why not just get a new body, anyway?"
 	icon_state = "khi_uniform_med_i"
 	item_state = "khi_uniform_med"
 	worn_state = "khi_uniform_med"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 50, rad = 5)
 
-/obj/item/clothing/under/rank/khi/eng //Engineering version
-	name = "KHI engineering suit"
-	desc = "Kitsuhana Heavy Industries uniform. One fit for an engineer, by the looks of it. Building the future, one disaster at a time."
+/obj/item/clothing/under/rank/ge/eng //Engineering version
+	name = "GE engineering suit"
+	desc = "Gilthari Exports uniform. One fit for an engineer, by the looks of it. Building the future, one disaster at a time."
 	icon_state = "khi_uniform_eng_i"
 	item_state = "khi_uniform_eng"
 	worn_state = "khi_uniform_eng"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 10)
 
-/obj/item/clothing/under/rank/khi/sci //Science version
-	name = "KHI science suit"
-	desc = "Kitsuhana Heavy Industries uniform. For performing science in, based on the color! Only SCIENCE can save us now."
+/obj/item/clothing/under/rank/ge/sci //Science version
+	name = "GE science suit"
+	desc = "Gilthari Exports uniform. For performing science in, based on the color! Only SCIENCE can save us now."
 	icon_state = "khi_uniform_sci_i"
 	item_state = "khi_uniform_sci"
 	worn_state = "khi_uniform_sci"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 5, bio = 0, rad = 5)
 
-/obj/item/clothing/under/rank/khi/fluff/aronai //Aro fluff version
-	name = "KHI meditech suit"
-	desc = "Kitsuhana Heavy Industries uniform. This one has the colors of a resleeving or mnemonics engineer. It has 'Aronai' written inside the top."
+/obj/item/clothing/under/rank/ge/fluff/aronai //Aro fluff version
+	name = "GE meditech suit"
+	desc = "Gilthari Exports uniform. This one has the colors of a resleeving or mnemonics engineer. It has 'Aronai' written inside the top."
 	icon_state = "khi_uniform_aro_i"
 	item_state = "khi_uniform_aro"
 	worn_state = "khi_uniform_aro"

--- a/code/modules/vore/fluffstuff/custom_clothes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_clothes_vr.dm
@@ -801,7 +801,7 @@
 /obj/item/weapon/rig/light/hacker/fluff/aronai
 	name = "VM-99-AAR suit module"
 	suit_type = "nano"
-	desc = "A thin collapsable spacesuit for synths from Kitsuhana Heavy Industries."
+	desc = "A thin collapsable spacesuit for synths from Vey-Med."
 	airtight = 1 //Not because it should be airtight but because suit coolers don't work w/o it.
 	armor = list(melee = 25, bullet = 15, laser = 15, energy = 60, bomb = 30, bio = 70, rad = 100)
 	air_type = null //No O2 tank, why would it have one?

--- a/code/modules/vore/fluffstuff/custom_items_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_items_vr.dm
@@ -478,7 +478,7 @@
 	</ol>
 	<br />
 	<h5>Purpose</h5>
-	<p>The Kitsuhana Life Crystal is a small device typically worn around the neck for the purpose of reporting your status to the HAVENS (Kitsuhana's High-AVailability ENgram Storage) system, so that appropriate measures can be taken in the case of your body's demise. The whole device is housed inside a pleasing-to-the-eye elongated diamond.</p>
+	<p>The Vey-Med Life Crystal is a small device typically worn around the neck for the purpose of reporting your status to the HAVENS (Vey-Med's High-AVailability ENgram Storage) system, so that appropriate measures can be taken in the case of your body's demise. The whole device is housed inside a pleasing-to-the-eye elongated diamond.</p>
 	<p>Upon your body's desmise, the crystal will send a transmission to HAVENS. Depending on your membership level, the appropriate actions can be taken to ensure that you are back up and enjoying existence as soon as possible.</p>
 
 	<p>Nanotrasen has negotiated a <i>FREE</i> Star membership for you in the HAVENS system, though an upgrade can be obtained depending on your citizenship and reputation level.</p>

--- a/code/modules/vore/fluffstuff/guns/nsfw.dm
+++ b/code/modules/vore/fluffstuff/guns/nsfw.dm
@@ -1,12 +1,12 @@
 // -------------- NSFW -------------
 /obj/item/weapon/gun/projectile/nsfw
-	name = "KHI-102b \'NSFW\'"
+	name = "HI-102b \'NSFW\'"
 	desc = "Variety is the spice of life! The 'Nanotech Selectable-Fire Weapon' is an unholy hybrid of an ammo-driven \
 	energy weapon that allows the user to mix and match their own fire modes. Up to three combinations of \
 	energy beams can be configured at once. Ammo not included."
 
 	description_info = "This gun is an energy weapon that uses interchangable microbatteries in a magazine. Each battery is a different beam type, and up to three can be loaded in the magazine. Each battery usually provides four discharges of that beam type, and multiple from the same type may be loaded to increase the number of shots for that type."
-	description_fluff = "The Kitsuhana 'Nanotech Selectable Fire Weapon' allows one to customize their loadout in the field, or before deploying, to achieve various results in a weapon they are already familiar with wielding."
+	description_fluff = "The Hesphaistos Industries 'Nanotech Selectable Fire Weapon' allows one to customize their loadout in the field, or before deploying, to achieve various results in a weapon they are already familiar with wielding."
 	description_antag = ""
 
 	icon = 'icons/vore/custom_guns_vr.dmi'
@@ -339,7 +339,7 @@
 	projectile_type = /obj/item/projectile/beam/growlaser
 */
 /obj/item/weapon/storage/secure/briefcase/nsfw_pack
-	name = "\improper KHI-102b \'NSFW\' gun kit"
+	name = "\improper HI-102b \'NSFW\' gun kit"
 	desc = "A storage case for a multi-purpose handgun. Variety hour!"
 	max_w_class = ITEMSIZE_NORMAL
 
@@ -351,7 +351,7 @@
 		new path(src)
 
 /obj/item/weapon/storage/secure/briefcase/nsfw_pack_hos
-	name = "\improper KHI-102b \'NSFW\' gun kit"
+	name = "\improper HI-102b \'NSFW\' gun kit"
 	desc = "A storage case for a multi-purpose handgun. Variety hour!"
 	max_w_class = ITEMSIZE_NORMAL
 

--- a/code/modules/vore/fluffstuff/guns/protector.dm
+++ b/code/modules/vore/fluffstuff/guns/protector.dm
@@ -1,11 +1,11 @@
 // -------------- Protector -------------
 /obj/item/weapon/gun/energy/protector
-	name = "\improper KHI-98a \'Protector\'"
-	desc = "The KHI-98a is the first firearm custom-designed for Nanotrasen by KHI. It features a powerful stun mode, and \
+	name = "\improper WT-98a \'Protector\'"
+	desc = "The HI-98a is a firearm custom-designed for Nanotrasen by HI. It features a powerful stun mode, and \
 	an alert-level-locked lethal mode, only usable on code blue and higher. It also features an integrated flashlight!"
 
 	description_info = "This gun can only be fired in lethal mode while on higher security alert levels. It is legal for sec to carry for this reason, since it cannot be used for lethal force until SOP allows it, in essence."
-	description_fluff = "The first 'commission' from a Kitsuhana citizen for NanoTrasen, this gun has a wireless connection to the computer's datacore to ensure it can't be used without authorization from heads of staff who have raised the alert level. Until then, *click*!"
+	description_fluff = "A for NanoTrasen, this gun has a wireless connection to the computer's datacore to ensure it can't be used without authorization from heads of staff who have raised the alert level. Until then, *click*!"
 	description_antag = "The gun can be emagged to remove the lethal security level restriction, allowing it to be fired on lethal mode at all times."
 
 	icon = 'icons/vore/custom_guns_vr.dmi'


### PR DESCRIPTION
Renames any/all items involving KHI, also removes from ship traffic fluff event. This is entirely fluff, no items have been removed or had their functionality changed. 
-Medical items are now Vey-Med
-Uniforms are now Gilthari Exports
-Weapons are now Hesphaistos Industries
-AR glasses are now Ward-Takahashi GMB
-Also commented out Virgo ship traffic (we're not in Virgo space) and Auream ship traffic (we don't have space elves) 