### PR TITLE
Higher Capacity ChemMaster

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -31,7 +31,7 @@
 
 /obj/machinery/chem_master/New()
 	..()
-	var/datum/reagents/R = new/datum/reagents(120)
+	var/datum/reagents/R = new/datum/reagents(900) //TFF: Ports Polaris edit to prevent the ChemMaster from ever losing a ton of chems.
 	reagents = R
 	R.my_atom = src
 


### PR DESCRIPTION
Ports Polaris' edit for the ChemMaster so that they never lose the last 180 units of a bluespace beaker's contents.