### PR TITLE
Halving can spawn timer for drones

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -145,9 +145,9 @@
 		pluralcheck = " [deathtimeminutes] minutes and"
 	var/deathtimeseconds = round((deathtime - deathtimeminutes * 600) / 10,1)
 
-	if (deathtime < 6000)
+	if (deathtime < 3000)
 		usr << "You have been dead for[pluralcheck] [deathtimeseconds] seconds."
-		usr << "You must wait 10 minutes to respawn as a drone!"
+		usr << "You must wait 5 minutes to respawn as a drone!"
 		return
 
 	var/list/all_fabricators = list()


### PR DESCRIPTION
from 10 minutes to 5.
Still prevents spam but is a more reasonable time