### PR TITLE
New Drone Ability and slight drone buff

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -125,8 +125,8 @@ var/list/mob_hat_cache = list()
 	add_language("Drone Talk", 1)
 
 	//They are unable to be upgraded, so let's give them a bit of a better battery.
-	cell.maxcharge = 10000
-	cell.charge = 10000
+	cell.maxcharge = 20000 //Original val 10000, doubled for ease of use of powertransmission circuit.
+	cell.charge = 20000
 
 	// NO BRAIN.
 	mmi = null
@@ -429,4 +429,19 @@ var/list/mob_hat_cache = list()
 
 	chassis = possible_chassis[choice]
 	verbs |= /mob/living/proc/hide
+
+//POWER Transmission code
+/mob/living/silicon/robot/drone/proc/transmitpower(var/power=250)
+	set category ="Robot Commands"
+	set name = "Transmit Power"
+	power = input(usr, "How much would you like to transmit? Keep in mind this is multiplied for each cell near you.", "Power Transmission", null)
+	if(power<=0 || power>=cell.maxcharge || power>=cell.charge) return //Safeties to not kill ourselves, also safeties to not use this to drain.
+	for(var/obj/item/weapon/cell/remotecell in range(1, src)) //assuming 1 = 1 tile next to us, if this works will lower to 0
+		if(power>=cell.charge) return //rechecking our initial safety so if we mass charge we dont die.
+		newcharge = remotecell.charge + power //What the battery is at after charge
+		if(newcharge<=remotecell.maxcharge) //Making sure we arent wasting power 
+			remotecell.give(power) //give is a proc native to cells that increases charge and updates the iconstate if needed
+			cell.give(-power)//TO BE TESTED, no idea if negative give works, once i've tested this i'll add this as a verb-shark
+		else return
+
 

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -438,7 +438,7 @@ var/list/mob_hat_cache = list()
 	if(power<=0 || power>=cell.maxcharge || power>=cell.charge) return //Safeties to not kill ourselves, also safeties to not use this to drain.
 	for(var/obj/item/weapon/cell/remotecell in range(1, src)) //assuming 1 = 1 tile next to us, if this works will lower to 0
 		if(power>=cell.charge) return //rechecking our initial safety so if we mass charge we dont die.
-		newcharge = remotecell.charge + power //What the battery is at after charge
+		var/newcharge = remotecell.charge + power //What the battery is at after charge
 		if(newcharge<=remotecell.maxcharge) //Making sure we arent wasting power 
 			remotecell.give(power) //give is a proc native to cells that increases charge and updates the iconstate if needed
 			cell.give(-power)//TO BE TESTED, no idea if negative give works, once i've tested this i'll add this as a verb-shark

--- a/code/modules/mob/living/silicon/robot/drone/drone_unify.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_unify.dm
@@ -23,17 +23,43 @@
 	
 	holder_type = /obj/item/weapon/holder/drone
 	//var/selected_icon = null //Can be compared to "Wideborg" will tell us in the future if we ar eusing non standardized icon.
+	
+/mob/living/silicon/robot/drone/unify/powerengineering
+	law_type = /datum/ai_laws/powerbank_drone
+	icon_state = "constructiondrone"
+	module_type = /obj/item/weapon/robot_module/drone/powerbank
+
 ////////////////////////////////////////
 //DRONE MODULES
 ////////////////////////////////////////
 /obj/item/weapon/robot_module/drone/unify
 	//yup this is nothing for now until we build more drone versions
+/obj/item/weapon/robot_module/drone/powerbank
+	name = "Engineering Power drone module"
+	hide_on_manifest = 1
+	channels = list("Engineering" = 1)
+	languages = list()
+
+/obj/item/weapon/robot_module/drone/powerbank/New() //Trading in the RCD for a Powergenerating device
+	..()
+	src.modules += new /obj/item/device/dogborg/sleeper/compactor/drone(src)
+	cell.maxcharge = 100000
+	cell.charge = 100000
 
 ////////////////////////////////////////
 //DRONE LAWS
 ////////////////////////////////////////
 //TODO: Remake drone laws, Add subroutine clause "If no maintenance are active nor maintenance crew your duties include maintenance"
 //TODO: Unify Drone law system, might be impossible due to how the ..() are structured may need to look into how to add additional laws if add_inherent fails.
+/datum/ai_laws/powerbank_drone
+	name = "Power Protocols"
+	law_header = "Power Protocols"
+
+/datum/ai_laws/powerbank_drone/New()
+	add_inherent_law("Do not interfere with the construction work of non-drones whenever possible.")
+	add_inherent_law("Repair, refit upgrade and restore power to your assigned vessel.")
+	add_inherent_law("Prevent unplanned damage to your assigned vessel wherever possible.")
+	..()
 
 ////////////////////////////////////////
 //DRONE HELLO WORLD
@@ -45,7 +71,14 @@
 	src << "Use <b>:d</b> to talk to other drones and <b>say</b> to speak silently to your nearby fellows."
 	src << "<b>You do not follow orders from anyone; not the AI, not humans, and not other synthetics.</b>."
 
-
+/mob/living/silicon/robot/drone/powerbank/welcome_drone()
+	src << "<b>You are a power restoration drone, an autonomous engineering and fabrication system.</b>."
+	src << "You are assigned to a Sol Central construction project. The name is irrelevant. Your task is to complete power restoration and subsystem integration as soon as possible."
+	src << "Use <b>:d</b> to talk to other drones and <b>say</b> to speak silently to your nearby fellows."
+	src << "<b>You do not follow orders from anyone; not the AI, not humans, and not other synthetics.</b>."
+/mob/living/silicon/robot/drone/unify/powerengineering/init()
+	..()
+	flavor_text = "It's a bulky engineering drone stamped with a Sol Central glyph."
 ////////////////////////////////////////
 //DRONE ITEMS (mostly mods of other items)
 ////////////////////////////////////////
@@ -67,6 +100,14 @@
 /obj/machinery/computer/drone_control/mining
 	req_access = list(access_mining)
 
+/obj/item/device/dogborg/sleeper/compactor/drone //Janihound gut. But for drones to generate power from garbage
+	name = "Minor Biocombustion Engine"
+	desc = "A mounted garbage compactor unit with fuel processor."
+	icon_state = "compactor"
+	injection_chems = null //So they don't have all the same chems as the medihound!
+	compactor = TRUE
+	max_item_count = 50 //Douibled since its purpose is garbage combustion
+
 ////////////////////////////////////////
 //DRONE FABRICATOR, ONE FOR ALL SYSTEM.
 ////////////////////////////////////////
@@ -78,6 +119,7 @@
 	drone_type = null //Gonna try to set this later
 	var/list/possible_drones = list("UNIFY Module (Same as Maintenance)" = /mob/living/silicon/robot/drone/unify,
 	"Construction Module" = /mob/living/silicon/robot/drone/construction,
+	"Power Restoration Module" = /mob/living/silicon/robot/drone/unify/powerengineering,
 	"Mining Module" = /mob/living/silicon/robot/drone/mining,
 	"Security Module" = /mob/living/silicon/robot/drone/security,
 	"Maintenance Module" = /mob/living/silicon/robot/drone,)
@@ -86,6 +128,9 @@
 //DRONE PROCS
 ////////////////////////////////////////
 //Drone Drone Procs
+/mob/living/silicon/robot/drone/unify/powerengineering/updatename()
+	real_name = "engineering drone ([rand(100,999)])"
+	name = real_name
 /mob/living/silicon/robot/drone/unify/updatename()
 	real_name = "Unified Drone Module ([rand(100,999)])" //UDMs, sounds kinda nice, maybe call them this Lore wise?
 	name = real_name

--- a/code/modules/mob/living/silicon/robot/drone/drone_unify.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_unify.dm
@@ -43,8 +43,7 @@
 /obj/item/weapon/robot_module/drone/powerbank/New() //Trading in the RCD for a Powergenerating device
 	..()
 	src.modules += new /obj/item/device/dogborg/sleeper/compactor/drone(src)
-	cell.maxcharge = 100000
-	cell.charge = 100000
+
 
 ////////////////////////////////////////
 //DRONE LAWS
@@ -128,6 +127,12 @@
 //DRONE PROCS
 ////////////////////////////////////////
 //Drone Drone Procs
+/mob/living/silicon/robot/drone/unify/powerengineering/New()
+	..()
+	cell.maxcharge = 100000
+	cell.charge = 100000
+	verbs |= /mob/living/silicon/robot/drone/proc/transmitpower
+
 /mob/living/silicon/robot/drone/unify/powerengineering/updatename()
 	real_name = "engineering drone ([rand(100,999)])"
 	name = real_name


### PR DESCRIPTION
Doubled drone power Capacity for QOL of new ability.
New ability is the ability to directly charge a powercell that is at least 1 tile in range

Not enabled yet, will most likely write a direct power drain first.
Planned: Engineering specific drone manufactured for minor construction and power relay (rebalanced construction drone that starts with a bigger cell) 
Drone cells can not be upgraded