### PR TITLE
Removed ckey restrictions from tails, wings, and ears because we don't do that here

### DIFF
--- a/code/modules/vore/appearance/sprite_accessories_taur_vr.dm
+++ b/code/modules/vore/appearance/sprite_accessories_taur_vr.dm
@@ -144,7 +144,7 @@
 	name = "Long Lizard Tail (Roiz Lizden)"
 	icon_state = "roiz_tail_s"
 	do_colouration = 0
-	ckeys_allowed = list("spoopylizz")
+//	ckeys_allowed = list("spoopylizz")
 
 /datum/sprite_accessory/tail/taur/wolf
 	name = "Wolf (Taur)"
@@ -326,7 +326,7 @@
 /datum/sprite_accessory/tail/taur/feline
 	name = "Feline (Taur)"
 	icon_state = "feline_s"
-	
+
 /datum/sprite_accessory/tail/taur/feline_wag
 	name = "Feline (Taur) (vwag)"
 	icon_state = "feline_s"
@@ -336,19 +336,19 @@
 	name = "Feline dual-color (Taur)"
 	icon_state = "feline_s"
 	extra_overlay = "feline_markings"
-	
+
 /datum/sprite_accessory/tail/taur/feline/feline_spots
 	name = "Feline spots (Taur)"
 	icon_state = "feline_s"
 	extra_overlay = "feline_spots"
-	
+
 /datum/sprite_accessory/tail/taur/feline/feline_spots_wag
 	name = "Feline spots (Taur) (vwag)"
 	icon_state = "feline_s"
 	ani_state = "feline_w"
 	extra_overlay = "feline_spots"
 	extra_overlay_w = "feline_spots_w"
-	
+
 /datum/sprite_accessory/tail/taur/feline/synthfeline
 	name = "SynthFeline dual-color (Taur)"
 	icon_state = "synthfeline_s"
@@ -403,19 +403,19 @@
 /datum/sprite_accessory/tail/taur/feline/tempest
 	name = "Feline (wickedtemp) (Taur)"
 	icon_state = "tempest_s"
-	ckeys_allowed = list("wickedtemp")
+//	ckeys_allowed = list("wickedtemp")
 
 //silencedmp5a5: Serdykov Antoz
 /datum/sprite_accessory/tail/taur/wolf/serdy
 	name = "CyberSerdy (silencedmp5a5) (Taur)"
 	icon_state = "serdy_s"
-	ckeys_allowed = list("silencedmp5a5")
+//	ckeys_allowed = list("silencedmp5a5")
 
 //liquidfirefly: Ariana Scol
 /datum/sprite_accessory/tail/taur/centipede
 	name = "Centipede (liquidfirefly) (Taur)"
 	icon_state = "ariana_s"
-	ckeys_allowed = list("liquidfirefly")
+//	ckeys_allowed = list("liquidfirefly")
 	do_colouration = 0
 
 	msg_owner_disarm_run = "You quickly push %prey to the ground with your leg!"
@@ -438,7 +438,7 @@
 	name = "Alraune (natje) (Taur)"
 	icon_state = "alraune_s"
 	ani_state = "alraune_closed_s"
-	ckeys_allowed = list("natje")
+//	ckeys_allowed = list("natje")
 	do_colouration = 0
 	can_ride = 0
 

--- a/code/modules/vore/appearance/sprite_accessories_vr.dm
+++ b/code/modules/vore/appearance/sprite_accessories_vr.dm
@@ -93,7 +93,7 @@
 	desc = ""
 	icon_state = "oni-h1"
 
-	
+
 /datum/sprite_accessory/ears/demon_horns1
 	name = "demon/unathi horns"
 	desc = ""
@@ -311,79 +311,79 @@
 	name = "quintail kitsune ears (Molenar)"
 	desc = ""
 	icon_state = "molenar-kitsune"
-	ckeys_allowed = list("molenar")
+//	ckeys_allowed = list("molenar")
 
 /datum/sprite_accessory/ears/lilimoth_antennae
 	name = "citheronia antennae (Kira72)"
 	desc = ""
 	icon_state = "lilimoth_antennae"
-	ckeys_allowed = list("kira72")
+//	ckeys_allowed = list("kira72")
 
 /datum/sprite_accessory/ears/molenar_deathclaw
 	name = "deathclaw ears (Molenar)"
 	desc = ""
 	icon_state = "molenar-deathclaw"
-	ckeys_allowed = list("molenar")
+//	ckeys_allowed = list("molenar")
 
 /datum/sprite_accessory/ears/miria_fluffdragon
 	name = "fluffdragon ears (Miria Masters)"
 	desc = ""
 	icon_state = "miria-fluffdragonears"
-	ckeys_allowed = list("miriamasters")
+//	ckeys_allowed = list("miriamasters")
 
 /datum/sprite_accessory/ears/miria_kitsune
 	name = "kitsune ears (Miria Masters)"
 	desc = ""
 	icon_state = "miria-kitsuneears"
-	ckeys_allowed = list("miriamasters")
+//	ckeys_allowed = list("miriamasters")
 
 /datum/sprite_accessory/ears/runac
 	name = "fennecsune ears (Runac)"
 	desc = ""
 	icon_state = "runac"
-	ckeys_allowed = list("rebcom1807")
+//	ckeys_allowed = list("rebcom1807")
 
 /datum/sprite_accessory/ears/kerena
 	name = "wingwolf ears (Kerena)"
 	desc = ""
 	icon_state = "kerena"
-	ckeys_allowed = list("somekindofpony")
+//	ckeys_allowed = list("somekindofpony")
 
 /datum/sprite_accessory/ears/rosey
 	name = "tritail kitsune ears (Rosey)"
 	desc = ""
 	icon_state = "rosey"
-	ckeys_allowed = list("joey4298")
+//	ckeys_allowed = list("joey4298")
 
-/datum/sprite_accessory/ears/aronai
-	name = "aronai ears/head (Aronai)"
-	desc = ""
-	icon_state = "aronai"
-	ckeys_allowed = list("arokha")
+///datum/sprite_accessory/ears/aronai //Commenting out as considering it's an entire custom head sprite it shouldn't be publicly available
+//	name = "aronai ears/head (Aronai)"
+//	desc = ""
+//	icon_state = "aronai"
+//	ckeys_allowed = list("arokha")
 
 /datum/sprite_accessory/ears/holly
 	name = "tigress ears (Holly Sharp)"
 	desc = ""
 	icon_state = "tigressears"
-	ckeys_allowed = list("hoodoo")
+//	ckeys_allowed = list("hoodoo")
 
 /datum/sprite_accessory/ears/molenar_inkling
 	name = "teal mature inkling hair (Kari Akiren)"
 	desc = ""
 	icon_state = "molenar-tentacle"
-	ckeys_allowed = list("molenar")
+//	ckeys_allowed = list("molenar")
 
 /datum/sprite_accessory/ears/shock
 	name = "pharoah hound ears (Shock Diamond)"
 	desc = ""
 	icon_state = "shock"
-	ckeys_allowed = list("icowom","cameron653")
+//	ckeys_allowed = list("icowom","cameron653")
 
 /datum/sprite_accessory/ears/alurane
 	name = "alurane ears/hair (Pumila)"
 	desc = ""
 	icon_state = "alurane-ears"
-	ckeys_allowed = list("natje")
+//	ckeys_allowed = list("natje")
 
 /*
 ////////////////////////////
@@ -487,19 +487,19 @@
 	name = "demon wings (Sepulchre)"
 	desc = ""
 	icon_state = "sepulchre_wings"
-	ckeys_allowed = list("sepulchre")
+//	ckeys_allowed = list("sepulchre")
 
 /datum/sprite_accessory/wing/miria_fluffdragon
 	name = "fluffdragon wings (Miria Masters)"
 	desc = ""
 	icon_state = "miria-fluffdragontail"
-	ckeys_allowed = list("miriamasters")
+//	ckeys_allowed = list("miriamasters")
 
 /datum/sprite_accessory/wing/scree
 	name = "green taj wings (Scree)"
 	desc = ""
 	icon_state = "scree-wings"
-	ckeys_allowed = list("scree")
+//	ckeys_allowed = list("scree")
 
 /datum/sprite_accessory/wing/liquidfirefly_gazer //I g-guess this could be considered wings?
 	name = "gazer eyestalks"
@@ -523,7 +523,7 @@
 	name = "wingwolf wings (Kerena)"
 	desc = ""
 	icon_state = "kerena-wings"
-	ckeys_allowed = list("somekindofpony")
+//	ckeys_allowed = list("somekindofpony")
 
 /datum/sprite_accessory/wing/snag
 	name = "xenomorph backplate"
@@ -756,61 +756,61 @@
 	name = "quintail kitsune tails (Molenar)"
 	desc = ""
 	icon_state = "molenar-kitsune"
-	ckeys_allowed = list("molenar")
+//	ckeys_allowed = list("molenar")
 
 /datum/sprite_accessory/tail/miria_fluffdragon
 	name = "fluffdragon tail (Miria Masters)"
 	desc = ""
 	icon_state = "miria-fluffdragontail"
-	ckeys_allowed = list("miriamasters")
+//	ckeys_allowed = list("miriamasters")
 
 /datum/sprite_accessory/tail/miria_kitsune
 	name = "Black kitsune tails (Miria Masters)"
 	desc = ""
 	icon_state = "miria-kitsunetail"
-	ckeys_allowed = list("miriamasters")
+//	ckeys_allowed = list("miriamasters")
 
 /datum/sprite_accessory/tail/molenar_deathclaw
 	name = "deathclaw bits (Molenar)"
 	desc = ""
 	icon_state = "molenar-deathclaw"
-	ckeys_allowed = list("molenar","silvertalismen","jertheace")
+//	ckeys_allowed = list("molenar","silvertalismen","jertheace")
 
 /datum/sprite_accessory/tail/runac
 	name = "fennecsune tails (Runac)"
 	desc = ""
 	icon_state = "runac"
-	ckeys_allowed = list("rebcom1807")
+//	ckeys_allowed = list("rebcom1807")
 
 /datum/sprite_accessory/tail/reika //Leaving this since it was too hard to split the wings from the tail.
 	name = "fox tail (+ beewings) (Reika)"
 	desc = ""
 	icon_state = "reika"
-	ckeys_allowed = list("rikaru19xjenkins")
+//	ckeys_allowed = list("rikaru19xjenkins")
 
 /datum/sprite_accessory/tail/rosey
 	name = "tritail kitsune tails (Rosey)"
 	desc = ""
 	icon_state = "rosey_three"
-	ckeys_allowed = list("joey4298")
+//	ckeys_allowed = list("joey4298")
 
 /datum/sprite_accessory/tail/rosey2
 	name = "pentatail kitsune tails (Rosey)" //I predict seven tails next. ~CK
 	desc = ""
 	icon_state = "rosey_five"
-	ckeys_allowed = list("joey4298")
+//	ckeys_allowed = list("joey4298")
 
 /datum/sprite_accessory/tail/scree
 	name = "green taj tail (Scree)"
 	desc = ""
 	icon_state = "scree"
-	ckeys_allowed = list("scree")
+//	ckeys_allowed = list("scree")
 
 /datum/sprite_accessory/tail/aronai
 	name = "aronai tail (Aronai)"
 	desc = ""
 	icon_state = "aronai"
-	ckeys_allowed = list("arokha")
+//	ckeys_allowed = list("arokha")
 
 /datum/sprite_accessory/tail/ketrai_wag
 	name = "fennix tail (vwag)"
@@ -836,7 +836,7 @@
 	name = "tigress tail (Holly)"
 	desc = ""
 	icon_state = "tigresstail"
-	ckeys_allowed = list("hoodoo")
+//	ckeys_allowed = list("hoodoo")
 
 /datum/sprite_accessory/tail/satyr
 	name = "goat legs, colorable"


### PR DESCRIPTION
As we do not allow custom sprites, body parts, etc., legacy custom sprites from Virgo have had their ckey restrictions removed and are now available to all. If you are the ckey holder of such a sprite, you have two options:
-You may allow your sprite to be used by all players of the server.
-You may request your sprite be commented out and usable by nobody, yourself included.