### PR TITLE
Teshari RIG Fix

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig_pieces_vr.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces_vr.dm
@@ -11,7 +11,8 @@
 		SPECIES_VULPKANI 		= 'icons/mob/species/vulpkanin/helmet.dmi',
 		SPECIES_PROMETHEAN		= 'icons/mob/species/skrell/helmet.dmi',
 		SPECIES_XENOHYBRID		= 'icons/mob/species/unathi/helmet.dmi',
-		SPECIES_VOX 			= 'icons/mob/species/vox/head.dmi'
+		SPECIES_VOX 			= 'icons/mob/species/vox/head.dmi',
+		SPECIES_TESHARI			= 'icons/mob/species/seromi/head.dmi'
 		)
 
 
@@ -29,7 +30,8 @@
 		SPECIES_VULPKANIN		= 'icons/mob/species/vulpkanin/suit.dmi',
 		SPECIES_PROMETHEAN		= 'icons/mob/species/skrell/suit.dmi',
 		SPECIES_XENOHYBRID		= 'icons/mob/species/unathi/suit.dmi',
-		SPECIES_VOX 			= 'icons/mob/species/vox/suit.dmi'
+		SPECIES_VOX 			= 'icons/mob/species/vox/suit.dmi',
+		SPECIES_TESHARI 		= 'icons/mob/species/seromi/suit.dmi'
 		)
 
 /obj/item/clothing/head/helmet/space/rig


### PR DESCRIPTION
It's so easy even a caveman could do it. Why was this broken in the first place?
Adds a line to actually point to the Teshari RIG sprites. Oh no I have to sprite another Pursuit RIG sprite now.