### PR TITLE
Solarmoth spawn count fix + vore check

### DIFF
--- a/code/modules/mob/living/simple_animal/vore/solargrub.dm
+++ b/code/modules/mob/living/simple_animal/vore/solargrub.dm
@@ -17,11 +17,11 @@ List of things solar grubs should be able to do:
 	icon_state = "solargrub"
 	icon_living = "solargrub"
 	icon_dead = "solargrub-dead"
-
+	
 	var/charge = null //CHOMPEDIT The amount of power we sucked off, in K as in THOUSANDS.
 	var/can_evolve = 1 //CHOMPEDIT VAR to decide whether this subspecies is allowed to become a queen
 	var/adult_form = "/mob/living/simple_animal/retaliate/solarmoth" //CHOMPEDIT VAR that decides what mob the queen form is. ex /mob/living/simple_animal/retaliate/solarmoth
-
+	
 	faction = "grubs"
 	maxHealth = 50 //grubs can take a lot of harm
 	health = 50
@@ -62,13 +62,13 @@ List of things solar grubs should be able to do:
 	var/apc_drain_rate = 750 //Going to see if grubs are better as a minimal bother. previous value : 4000
 	var/powerdraw = 100000 // previous value 150000
 
-
+	
 /mob/living/simple_animal/retaliate/solargrub/PunchTarget()
 	if(target_mob&& prob(emp_chance))
 		target_mob.emp_act(4) //The weakest strength of EMP
 		visible_message("<span class='danger'>The grub releases a powerful shock!</span>")
 	..()
-
+	
 /mob/living/simple_animal/retaliate/solargrub/Life()
 	. = ..()
 	if(!. || ai_inactive) return
@@ -97,13 +97,13 @@ List of things solar grubs should be able to do:
 		else if(!attached && anchored)
 			anchored = 0
 			PN = null
+			
 
-
-		if(prob(2) && charge >= 16000 && can_evolve == 1 && moth_amount.len <= 2) //it's reading from the moth_amount global list to determine if it can evolve.
+		if(prob(2) && charge >= 16000 && can_evolve == 1 && moth_amount.len <= 1) //it's reading from the moth_amount global list to determine if it can evolve.
 			anchored = 0
 			PN = attached.powernet
 			death_star()
-
+					
 
 /mob/living/simple_animal/retaliate/solargrub/proc/death_star()
 	visible_message("<span class='warning'>\The [src]'s shell rips open and evolves!</span>")
@@ -114,8 +114,7 @@ List of things solar grubs should be able to do:
 	vore_bump_chance = 50
 	vore_bump_emote = "applies minimal effort to try and slurp up"
 	vore_active = 1
-	vore_capacity = 3 //Raising to three rather than two only due to how common they are
-	vore_ignores_undigestable = 0
+	vore_capacity = 1
 	vore_pounce_chance = 0 //grubs only eat incapacitated targets
 	vore_default_mode = DM_DIGEST
 

--- a/code/modules/mob/living/simple_animal/vore/solargrub.dm
+++ b/code/modules/mob/living/simple_animal/vore/solargrub.dm
@@ -102,6 +102,9 @@ List of things solar grubs should be able to do:
 		if(prob(2) && charge >= 16000 && can_evolve == 1 && moth_amount.len <= 1) //it's reading from the moth_amount global list to determine if it can evolve.
 			anchored = 0
 			PN = attached.powernet
+			release_vore_contents()
+			prey_excludes.Cut()
+			stop_consumption()
 			death_star()
 					
 

--- a/code/modules/mob/living/simple_animal/vore/solargrub.dm
+++ b/code/modules/mob/living/simple_animal/vore/solargrub.dm
@@ -17,11 +17,11 @@ List of things solar grubs should be able to do:
 	icon_state = "solargrub"
 	icon_living = "solargrub"
 	icon_dead = "solargrub-dead"
-	
+
 	var/charge = null //CHOMPEDIT The amount of power we sucked off, in K as in THOUSANDS.
 	var/can_evolve = 1 //CHOMPEDIT VAR to decide whether this subspecies is allowed to become a queen
 	var/adult_form = "/mob/living/simple_animal/retaliate/solarmoth" //CHOMPEDIT VAR that decides what mob the queen form is. ex /mob/living/simple_animal/retaliate/solarmoth
-	
+
 	faction = "grubs"
 	maxHealth = 50 //grubs can take a lot of harm
 	health = 50
@@ -62,13 +62,13 @@ List of things solar grubs should be able to do:
 	var/apc_drain_rate = 750 //Going to see if grubs are better as a minimal bother. previous value : 4000
 	var/powerdraw = 100000 // previous value 150000
 
-	
+
 /mob/living/simple_animal/retaliate/solargrub/PunchTarget()
 	if(target_mob&& prob(emp_chance))
 		target_mob.emp_act(4) //The weakest strength of EMP
 		visible_message("<span class='danger'>The grub releases a powerful shock!</span>")
 	..()
-	
+
 /mob/living/simple_animal/retaliate/solargrub/Life()
 	. = ..()
 	if(!. || ai_inactive) return
@@ -97,16 +97,15 @@ List of things solar grubs should be able to do:
 		else if(!attached && anchored)
 			anchored = 0
 			PN = null
-			
 
-		if(prob(2) && charge >= 16000 && can_evolve == 1 && moth_amount.len <= 1) //it's reading from the moth_amount global list to determine if it can evolve.
+
+		if(prob(2) && charge >= 16000 && can_evolve == 1 && moth_amount.len <= 2) //it's reading from the moth_amount global list to determine if it can evolve.
 			anchored = 0
 			PN = attached.powernet
 			release_vore_contents()
 			prey_excludes.Cut()
-			stop_consumption()
 			death_star()
-					
+
 
 /mob/living/simple_animal/retaliate/solargrub/proc/death_star()
 	visible_message("<span class='warning'>\The [src]'s shell rips open and evolves!</span>")
@@ -117,7 +116,8 @@ List of things solar grubs should be able to do:
 	vore_bump_chance = 50
 	vore_bump_emote = "applies minimal effort to try and slurp up"
 	vore_active = 1
-	vore_capacity = 1
+	vore_capacity = 3 //Raising to three rather than two only due to how common they are
+	vore_ignores_undigestable = 0
 	vore_pounce_chance = 0 //grubs only eat incapacitated targets
 	vore_default_mode = DM_DIGEST
 


### PR DESCRIPTION
Because byond likes to think that 2 = 3.
Should now only ever evolve 2 solargrubs. 

ALSO! Added a smol safety. If it ever somehow miraculously decides to evolve after it has eaten someone, it will spit out its contents. The fear is that it might delete the character it's eating from qdel, as far as we know it doesn't, but the safety is here anyway. It'd be under VERY RARE circumstances that this could happen.