### PR TITLE
Ranged cooldown

### DIFF
--- a/code/modules/mob/living/simple_animal/aliens/alien.dm
+++ b/code/modules/mob/living/simple_animal/aliens/alien.dm
@@ -68,6 +68,8 @@
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	ranged = 1
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 	projectiletype = /obj/item/projectile/energy/neurotoxin/toxic
 	projectilesound = 'sound/weapons/pierce.ogg'
 
@@ -81,6 +83,8 @@
 	move_to_delay = 5
 	maxHealth = 200
 	health = 200
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 
 	pixel_x = -16
 	old_x = -16
@@ -97,6 +101,8 @@
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	ranged = 1
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 	move_to_delay = 3
 	projectiletype = /obj/item/projectile/energy/neurotoxin/toxic
 	projectilesound = 'sound/weapons/pierce.ogg'
@@ -115,6 +121,8 @@
 	health = 400
 	meat_amount = 5
 	speed = 1
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 
 	pixel_x = -16
 	old_x = -16
@@ -132,6 +140,8 @@
 	melee_damage_lower = 15
 	melee_damage_upper = 25
 	speed = 2
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 
 	pixel_x = -32
 	old_x = -32

--- a/code/modules/mob/living/simple_animal/aliens/drone.dm
+++ b/code/modules/mob/living/simple_animal/aliens/drone.dm
@@ -22,6 +22,8 @@
 	a_intent = I_HURT
 	ranged = 1
 	rapid = 1
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 	projectiletype = /obj/item/projectile/beam/drone
 	projectilesound = 'sound/weapons/laser3.ogg'
 	destroy_surroundings = 0
@@ -274,9 +276,13 @@
 
 /obj/item/projectile/beam/drone
 	damage = 15
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 
 /obj/item/projectile/beam/pulse/drone
 	damage = 10
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 
 // A slightly easier drone, for POIs.
 // Difference is that it should not be faster than you.
@@ -284,3 +290,5 @@
 	desc = "An automated combat drone with an aged apperance."
 	returns_home = TRUE
 	move_to_delay = 6
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is

--- a/code/modules/mob/living/simple_animal/aliens/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/aliens/hivebot.dm
@@ -10,9 +10,7 @@
 	icon_state = "basic"
 	icon_living = "basic"
 	icon_dead = "basic"
-	
-	var/zergoverride=0
-	
+
 	faction = "hivebot"
 	intelligence_level = SA_ROBOTIC
 	maxHealth = 3 LASERS_TO_KILL
@@ -73,6 +71,8 @@
 	name = "ranged hivebot"
 	desc = "A robot.  It has a simple ballistic weapon."
 	ranged = 1
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 	maxHealth = 2 LASERS_TO_KILL
 	health = 2 LASERS_TO_KILL
 
@@ -82,6 +82,8 @@
 	desc = "A robot.  It has a fast firing ballistic rifle."
 	icon_living = "strong"
 	rapid = 1
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 	maxHealth = 2 LASERS_TO_KILL
 	health = 2 LASERS_TO_KILL
 
@@ -93,6 +95,8 @@
 	projectilesound = 'sound/weapons/Laser.ogg'
 	icon_living = "engi"
 	ranged = TRUE
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 	maxHealth = 2 LASERS_TO_KILL
 	health = 2 LASERS_TO_KILL
 
@@ -114,6 +118,8 @@
 	health = 4 LASERS_TO_KILL
 	melee_damage_lower = 15
 	melee_damage_upper = 15
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 
 // Also beefy, but tries to stay at their 'home', ideal for base defense.
 /mob/living/simple_animal/hostile/hivebot/range/guard
@@ -139,13 +145,12 @@
 
 /mob/living/simple_animal/hostile/hivebot/death()
 	..()
-	if(!zergoverride)//CHOMPEDIT OVerriding death for zerg
-		visible_message("<b>[src]</b> blows apart!")
-		new /obj/effect/decal/cleanable/blood/gibs/robot(src.loc)
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(3, 1, src)
-		s.start()
-		qdel(src)
+	visible_message("<b>[src]</b> blows apart!")
+	new /obj/effect/decal/cleanable/blood/gibs/robot(src.loc)
+	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+	s.set_up(3, 1, src)
+	s.start()
+	qdel(src)
 
 /mob/living/simple_animal/hostile/hivebot/speech_bubble_appearance()
 	return "synthetic_evil"

--- a/code/modules/mob/living/simple_animal/animals/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/animals/giant_spider.dm
@@ -138,6 +138,8 @@ Nurse Family
 	projectilesound = 'sound/weapons/thudswoosh.ogg'
 	projectiletype = /obj/item/projectile/bola
 	ranged = 1
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 	firing_lines = 1
 	cooperative = 1
 	shoot_range = 5
@@ -347,6 +349,8 @@ Guard Family
 	melee_damage_upper = 25
 
 	ranged = 1
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 100 	//How long, in deciseconds, the cooldown of ranged attacks is
 	projectilesound = 'sound/weapons/taser2.ogg'
 	projectiletype = /obj/item/projectile/beam/stun/weak
 	firing_lines = 1

--- a/code/modules/mob/living/simple_animal/humanoids/mechamobs.dm
+++ b/code/modules/mob/living/simple_animal/humanoids/mechamobs.dm
@@ -45,6 +45,8 @@
 
 	ranged = 1
 	rapid = 1
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 	projectiletype = /obj/item/projectile/beam/midlaser
 	projectilesound = 'sound/weapons/laser.ogg'
 

--- a/code/modules/mob/living/simple_animal/humanoids/pirate.dm
+++ b/code/modules/mob/living/simple_animal/humanoids/pirate.dm
@@ -57,6 +57,8 @@
 	icon_dead = "piratemelee_dead"
 
 	ranged = 1
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 	projectiletype = /obj/item/projectile/beam
 	projectilesound = 'sound/weapons/laser.ogg'
 

--- a/code/modules/mob/living/simple_animal/humanoids/russian.dm
+++ b/code/modules/mob/living/simple_animal/humanoids/russian.dm
@@ -52,6 +52,8 @@
 	icon_living = "russianranged"
 
 	ranged = 1
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 	projectiletype = /obj/item/projectile/bullet
 	casingtype = /obj/item/ammo_casing/spent
 	projectilesound = 'sound/weapons/Gunshot.ogg'

--- a/code/modules/mob/living/simple_animal/humanoids/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/humanoids/syndicate.dm
@@ -146,6 +146,8 @@
 
 	ranged = 1
 	rapid = 1
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 	projectiletype = /obj/item/projectile/bullet/pistol/medium
 //	casingtype = /obj/item/ammo_casing/spent	//Makes infinite stacks of bullets when put in PoIs.
 	projectilesound = 'sound/weapons/Gunshot_light.ogg'
@@ -156,6 +158,8 @@
 	icon_state = "syndicateranged_laser"
 	icon_living = "syndicateranged_laser"
 	rapid = 0
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 	projectiletype = /obj/item/projectile/beam/midlaser
 	projectilesound = 'sound/weapons/Laser.ogg'
 
@@ -165,6 +169,8 @@
 	icon_state = "syndicateranged_ionrifle"
 	icon_living = "syndicateranged_ionrifle"
 	rapid = 0
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 	projectiletype = /obj/item/projectile/ion
 	projectilesound = 'sound/weapons/Laser.ogg'
 
@@ -174,7 +180,8 @@
 	name = "space mercenary" //VOREStation Edit
 	icon_state = "syndicaterangedpsace"
 	icon_living = "syndicaterangedpsace"
-
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 	speed = 0
 
 	min_oxy = 0

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -113,6 +113,8 @@
 	var/projectiletype				// The projectiles I shoot
 	var/projectilesound				// The sound I make when I do it
 	var/casingtype					// What to make the hugely laggy casings pile out of
+	var/ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	var/ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 
 	//Mob melee settings
 	var/melee_damage_lower = 2		// Lower bound of randomized melee damage
@@ -1264,10 +1266,18 @@
 		PunchTarget()
 		return 1
 	//Open fire!
-	else if(ranged && (distance <= shoot_range))
+	if(ranged && (distance <= shoot_range) && ranged_cooldown <= world.time)
+		stop_automated_movement = 0
 		ai_log("AttackTarget() ranged",3)
 		ShootTarget(target_mob)
 		return 1
+		
+	else if(ranged && !target_mob.canmove)
+		LostTarget()
+		ai_log("AttackTarget() resting, closing distance",3)
+		handle_stance(STANCE_ATTACK)
+		return 0
+		
 	//They ran away!
 	else
 		ai_log("AttackTarget() out of range!",3)
@@ -1347,7 +1357,7 @@
 		Shoot(target, src.loc, src)
 		if(casingtype)
 			new casingtype
-
+	ranged_cooldown = world.time + ranged_cooldown_time
 	return 1
 
 //Check firing lines for faction_friends (if we're not cooperative, we don't care)
@@ -1754,3 +1764,6 @@
 
 /mob/living/simple_animal/get_nametag_desc(mob/user)
 	return "<i>[tt_desc]</i>"
+
+	
+	


### PR DESCRIPTION
All ranged mobs now follow two new variables:
ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is

All mobs with ranged attacks now shoot once every 3 seconds. Believe it or not, this is actually slower than when they just kept trying to spam shooting.

Except for the taser spider. Gave that monster a 10 second cooldown. He's still broken because he'll infinitely stun lock you if you decide to just stand there.