### PR TITLE
Ranged Cooldown

### DIFF
--- a/code/modules/mob/living/simple_animal/animals/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/animals/giant_spider.dm
@@ -138,6 +138,8 @@ Nurse Family
 	projectilesound = 'sound/weapons/thudswoosh.ogg'
 	projectiletype = /obj/item/projectile/bola
 	ranged = 1
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 	firing_lines = 1
 	cooperative = 1
 	shoot_range = 5
@@ -347,6 +349,8 @@ Guard Family
 	melee_damage_upper = 25
 
 	ranged = 1
+	ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	ranged_cooldown_time = 100 	//How long, in deciseconds, the cooldown of ranged attacks is
 	projectilesound = 'sound/weapons/taser2.ogg'
 	projectiletype = /obj/item/projectile/beam/stun/weak
 	firing_lines = 1

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -113,6 +113,8 @@
 	var/projectiletype				// The projectiles I shoot
 	var/projectilesound				// The sound I make when I do it
 	var/casingtype					// What to make the hugely laggy casings pile out of
+	var/ranged_cooldown = 0 		//What the starting cooldown is on ranged attacks
+	var/ranged_cooldown_time = 30 	//How long, in deciseconds, the cooldown of ranged attacks is
 
 	//Mob melee settings
 	var/melee_damage_lower = 2		// Lower bound of randomized melee damage
@@ -1264,10 +1266,18 @@
 		PunchTarget()
 		return 1
 	//Open fire!
-	else if(ranged && (distance <= shoot_range))
+	if(ranged && (distance <= shoot_range) && ranged_cooldown <= world.time)
+		stop_automated_movement = 0
 		ai_log("AttackTarget() ranged",3)
 		ShootTarget(target_mob)
 		return 1
+		
+	else if(ranged && !target_mob.canmove)
+		LostTarget()
+		ai_log("AttackTarget() resting, closing distance",3)
+		handle_stance(STANCE_ATTACK)
+		return 0
+		
 	//They ran away!
 	else
 		ai_log("AttackTarget() out of range!",3)
@@ -1347,7 +1357,7 @@
 		Shoot(target, src.loc, src)
 		if(casingtype)
 			new casingtype
-
+	ranged_cooldown = world.time + ranged_cooldown_time
 	return 1
 
 //Check firing lines for faction_friends (if we're not cooperative, we don't care)
@@ -1754,3 +1764,6 @@
 
 /mob/living/simple_animal/get_nametag_desc(mob/user)
 	return "<i>[tt_desc]</i>"
+
+	
+	

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -1266,17 +1266,11 @@
 		PunchTarget()
 		return 1
 	//Open fire!
-	if(ranged && (distance <= shoot_range) && ranged_cooldown <= world.time)
-		stop_automated_movement = 0
+	else if(ranged && (distance <= shoot_range) && ranged_cooldown <= world.time)
 		ai_log("AttackTarget() ranged",3)
 		ShootTarget(target_mob)
 		return 1
 		
-	else if(ranged && !target_mob.canmove)
-		LostTarget()
-		ai_log("AttackTarget() resting, closing distance",3)
-		handle_stance(STANCE_ATTACK)
-		return 0
 		
 	//They ran away!
 	else


### PR DESCRIPTION
All ranged mobs now follow two new variables:
ranged_cooldown = 0 //What the starting cooldown is on ranged attacks
ranged_cooldown_time = 30 //How long, in deciseconds, the cooldown of ranged attacks is

All mobs with ranged attacks now shoot once every 3 seconds. Believe it or not, this is actually slower than when they just kept trying to spam shooting.

Except for the taser spider. Gave that monster a 10 second cooldown. He's still broken because he'll infinitely stun lock you if you decide to just stand there.