### PR TITLE
Mobs now stand up if pinned

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -75,6 +75,8 @@
 	var/recruit_cmd_str = "Hey,"	// The thing you prefix commands with when bossing them around
 	var/intelligence_level = SA_ANIMAL// How 'smart' the mob is ICly, used to deliniate between animal, robot, and humanoid SAs.
 
+	var/norest = 1 //mob will automatically unrest if not player controlled.
+
 	//Mob environment settings
 	var/minbodytemp = 250			// Minimum "okay" temperature in kelvin
 	var/maxbodytemp = 350			// Maximum of above
@@ -359,7 +361,13 @@
 	if(life_disabled)
 		return 0
 	//VOREStation Edit End
-
+	
+	//CHOMPSTATION edit
+	if(resting && !client && norest)
+		resting = !resting
+		update_icon()
+	//CHOMPSTATION EDIT END
+	
 	..()
 
 	//Health

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -75,7 +75,7 @@
 	var/recruit_cmd_str = "Hey,"	// The thing you prefix commands with when bossing them around
 	var/intelligence_level = SA_ANIMAL// How 'smart' the mob is ICly, used to deliniate between animal, robot, and humanoid SAs.
 
-	var/norest = 1 //mob will automatically unrest if not player controlled.
+	var/noresting = 1 //mob will automatically unrest if not player controlled.
 
 	//Mob environment settings
 	var/minbodytemp = 250			// Minimum "okay" temperature in kelvin
@@ -363,7 +363,7 @@
 	//VOREStation Edit End
 	
 	//CHOMPSTATION edit
-	if(resting && !client && norest)
+	if(resting && !client && noresting)
 		resting = !resting
 		update_icon()
 	//CHOMPSTATION EDIT END


### PR DESCRIPTION
new simple_animal variable "norest"

If set to 1 the mob will automatically stop resting at the start of the life cycle.
For any mob that should be allowed to rest simply add a `norest = 0` into their files, this fixes retaliate mob combat.