### PR TITLE
Increased Solargrub evolution time

### DIFF
--- a/code/modules/mob/living/simple_animal/vore/solargrub.dm
+++ b/code/modules/mob/living/simple_animal/vore/solargrub.dm
@@ -99,7 +99,7 @@ List of things solar grubs should be able to do:
 			PN = null
 
 
-		if(prob(2) && charge >= 16000 && can_evolve == 1 && moth_amount.len <= 2) //it's reading from the moth_amount global list to determine if it can evolve.
+		if(prob(1) && charge >= 32000 && can_evolve == 1 && moth_amount.len <= 2) //it's reading from the moth_amount global list to determine if it can evolve.
 			anchored = 0
 			PN = attached.powernet
 			release_vore_contents()


### PR DESCRIPTION
Changed required evolution charge from 16000 to 32000.
Changed evolution probability from 2% to 1%.

Originally it would take about maybe 7 minutes for a grub to evolve. Should take more than double that now.