### PR TITLE
Fixing Synx Vorecode

### DIFF
--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -129,9 +129,9 @@
 			if(istype(M,/mob/living/simple_animal/retaliate/synx))
 				var/syntox = digest_brute+digest_burn
 				owner.adjustToxLoss(syntox)
-				if(M.health <= M.maxHealth)
-					M.health = M.health + syntox*2
-			
+				M.adjustBruteLoss(-syntox*2) //Should automaticaly clamp to 0
+				M.adjustFireLoss(-syntox*2) //Should automaticaly clamp to 0
+				//END SYNX hook.
 			// Deal digestion damage (and feed the pred)
 			var/old_brute = M.getBruteLoss()
 			var/old_burn = M.getFireLoss()


### PR DESCRIPTION
They should now properly be healed by twice the digestion damage they take.
Since it now directly applies to their specific damage pools they should automatically clamp to 0 so overhealing should not be an issue..

Let's hope article 13 wont make the concept of digestion illegal.