### PR TITLE
Limit break prepare; micro limiter

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -108,7 +108,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 			power *= M.outgoing_melee_damage_percent
 	if(HULK in user.mutations)
 		power *= 2
-	/CHOMPEDIT: Damage nulling code
+	//CHOMPEDIT: Damage nulling code
 	if(iscarbon(user))
 		var/mob/living/carbon/nerd = user
 		var/mysize = nerd.size_multiplier

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -108,5 +108,15 @@ avoid code duplication. This includes items that may sometimes act as a standard
 			power *= M.outgoing_melee_damage_percent
 	if(HULK in user.mutations)
 		power *= 2
+	/CHOMPEDIT: Damage nulling code
+	if(iscarbon(user))
+		var/mob/living/carbon/nerd = user
+		var/mysize = nerd.size_multiplier
+		if(mysize <= 0.24)
+			power = 0
+		else if(mysize <= 0.50)
+			power = power/2
+	//CHOMPEDIT: smoll code end
+	
 	return target.hit_with_weapon(src, user, power, hit_zone)
 


### PR DESCRIPTION
Code to null any damage done by someone below 25% size.
Additionally any weapon used by someone below 50% should cause 50% damage.
The 50% damage reduction from being smoll applies after all other modifiers for damage are calculated.