### PR TITLE
Stun baton: Taking the harm out of disarm

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -166,7 +166,7 @@
 		var/mob/living/carbon/human/H = target
 		affecting = H.get_organ(hit_zone)
 
-	if(user.a_intent == I_HURT || user.a_intent == I_DISARM)
+	if(user.a_intent == I_HURT)
 		. = ..()
 		//whacking someone causes a much poorer electrical contact than deliberately prodding them.
 		agony *= 0.5


### PR DESCRIPTION
Apparently poking someone with a stun baton on disarm intent counted as harm intent. Removing that. It's called a HARM baton, hot a DISARM baton.