### PR TITLE
New stun beam type + Gun

### DIFF
--- a/code/modules/projectiles/guns/energy/stun_vr.dm
+++ b/code/modules/projectiles/guns/energy/stun_vr.dm
@@ -4,3 +4,19 @@
 
 /obj/item/weapon/gun/energy/stunrevolver
 	charge_cost = 400
+
+//CHOMPEDIT: 
+/obj/item/weapon/gun/energy/stunrevolver/oneshot
+	desc = "A heavily modified LAEP20 Zeus. It fires a beam instead of an electrode. The massive recoil makes it only useful as a last resort weapon."
+	charge_cost = 2400
+	projectile_type = /obj/item/projectile/beam/stun/oneshot
+	
+/obj/item/weapon/gun/energy/stunrevolver/oneshot/Fire(atom/target, mob/living/user, clickparams, pointblank=0, reflex=0)
+	..()
+	if(iscarbon(user))
+		var/mob/living/carbon/nerd = user
+		var/mysize = nerd.size_multiplier 
+		nerd.Weaken(3-mysize) //200% gets the knockdown micros usually get now from firing a gun. Micros get their base knockdown + this.
+		nerd.adjustBruteLoss(10-mysize*4) //This means 200% = 10-8; 100% = 10-4; etc
+
+

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -18,6 +18,7 @@
 	muzzle_type = /obj/effect/projectile/laser/muzzle
 	tracer_type = /obj/effect/projectile/laser/tracer
 	impact_type = /obj/effect/projectile/laser/impact
+	
 
 /obj/item/projectile/beam/practice
 	name = "laser"
@@ -211,3 +212,11 @@
 	name = "stun beam"
 	icon_state = "stun"
 	agony = 35
+
+//CHOMPEDIT: Charge beam that drains all power
+/obj/item/projectile/beam/stun/oneshot
+	name = "Overdrive Stun beam"
+	light_color = "#AA00FF"
+	//shotcost = 2400
+	agony = 240
+//CHOMPEDIT END.


### PR DESCRIPTION
single shot stun weapon beam and gun.
Beam proportionally scaled agony based on powerdrain (40*6)
Beam light colour AA00FF

Single shot stun gun, uses all of its energy for 1 singular shot that is a guranteed stun on hit.
Downsides: Massive power consumption, Massive recoil affecting anyone recoil effect scales with size and stacks with micro gun base recoil.