### PR TITLE
Reagent Implants Loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_implants.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_implants.dm
@@ -2,8 +2,13 @@
 
 
 /datum/gear/implant
-	exploitable = 0
+	display_name = "implant, tracking"
+	path = /obj/item/weapon/implant/tracking/weak
+	cost = 0 //VOREStation Edit. Changed cost to 0
+	slot = "implant"
+	exploitable = 1
 	sort_category = "Implants"
+
 /* VOREStation Edit - Make languages great again
 /datum/gear/utility/implant/eal //This does nothing if you don't actually know EAL.
 	display_name = "implant, language, EAL"
@@ -12,21 +17,12 @@
 	slot = "implant"
 	exploitable = 1*/
 
-/datum/gear/implant/tracking
-	display_name = "implant, tracking"
-	path = /obj/item/weapon/implant/tracking/weak
-	cost = 0 //VOREStation Edit. Changed cost to 0
-	slot = "implant"
-	exploitable = 1
-
 //Reagent implants - cost of 2 to reduce chance of abuse
 /datum/gear/implant/reagent_generator
-	exploitable = 0
-	cost = 2
-
-/datum/gear/implant/reagent_generator/milk
 	display_name = "implant, milk production"
 	path = /obj/item/weapon/implanter/reagent_generator/milk
+	exploitable = 0
+	cost = 2
 
 /datum/gear/implant/reagent_generator/egg
 	display_name = "implant, egg production"

--- a/code/modules/client/preference_setup/loadout/loadout_implants.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_implants.dm
@@ -1,0 +1,33 @@
+//TFF 29/4/19: Add implants category, includes reagent implanters
+
+
+/datum/gear/implant
+	exploitable = 0
+	sort_category = "Implants"
+/* VOREStation Edit - Make languages great again
+/datum/gear/utility/implant/eal //This does nothing if you don't actually know EAL.
+	display_name = "implant, language, EAL"
+	path = /obj/item/weapon/implant/language/eal
+	cost = 2
+	slot = "implant"
+	exploitable = 1*/
+
+/datum/gear/implant/tracking
+	display_name = "implant, tracking"
+	path = /obj/item/weapon/implant/tracking/weak
+	cost = 0 //VOREStation Edit. Changed cost to 0
+	slot = "implant"
+	exploitable = 1
+
+//Reagent implants - cost of 2 to reduce chance of abuse
+/datum/gear/implant/reagent_generator
+	exploitable = 0
+	cost = 2
+
+/datum/gear/implant/reagent_generator/milk
+	display_name = "implant, milk production"
+	path = /obj/item/weapon/implanter/reagent_generator/milk
+
+/datum/gear/implant/reagent_generator/egg
+	display_name = "implant, egg production"
+	path = /obj/item/weapon/implanter/reagent_generator/egg

--- a/code/modules/client/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility.dm
@@ -115,22 +115,7 @@
 	display_name = "cell, device"
 	path = /obj/item/weapon/cell/device
 
-/datum/gear/utility/implant
-	exploitable = 1
-/* VOREStation Edit - Make languages great again
-/datum/gear/utility/implant/eal //This does nothing if you don't actually know EAL.
-	display_name = "implant, language, EAL"
-	path = /obj/item/weapon/implant/language/eal
-	cost = 2
-	slot = "implant"
-	exploitable = 1*/
-
-/datum/gear/utility/implant/tracking
-	display_name = "implant, tracking"
-	path = /obj/item/weapon/implant/tracking/weak
-	cost = 0 //VOREStation Edit. Changed cost to 0
-	slot = "implant"
-	exploitable = 1
+//TFF 29/4/19: remove implants, move to loadout_implants.dm
 
 /datum/gear/utility/pen
 	display_name = "Fountain Pen"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -167,7 +167,7 @@
 				update |= temp.take_damage(b_loss * 0.05, f_loss * 0.05, used_weapon = weapon_message)
 	if(update)	UpdateDamageIcon()
 
-/mob/living/carbon/human/proc/implant_loadout(var/datum/gear/G = new/datum/gear/utility/implant)
+/mob/living/carbon/human/proc/implant_loadout(var/datum/gear/G = new/datum/gear/implant)	//TFF 29/4/19: filepath change due to loadout change
 	var/obj/item/weapon/implant/I = new G.path(src)
 	I.imp_in = src
 	I.implanted = 1

--- a/code/modules/vore/fluffstuff/custom_items_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_items_vr.dm
@@ -615,6 +615,93 @@
 	taurtype = /datum/sprite_accessory/tail/taur/feline/tempest
 	no_message = "These saddlebags seem to be fitted for someone else, and keep slipping off!"
 
+//TFF 29/4/19: Add standardised reagent generators for loadout
+/obj/item/weapon/implant/reagent_generator/milk
+	name = "milk generation implant"
+	desc = "It's an implant you can use to make milk from yourself!"
+	generated_reagents = list("milk" = 2)
+	reagent_name = "milk"
+	usable_volume = 1000
+
+	empty_message = list("Your breasts are almost completely drained!")
+	full_message = list("Your teats feel heavy and swollen!")
+	emote_descriptor = list("squeezes milk", "tugs on their breasts, milking them")
+	self_emote_descriptor = list("squeeze")
+	random_emote = list("moos quietly")
+	verb_name = "Milk"
+	verb_desc = "Grab their nipples and milk them into a container! May cause blushing and groaning."
+
+/obj/item/weapon/implanter/reagent_generator/milk
+	implant_type = /obj/item/weapon/implant/reagent_generator/milk
+
+/obj/item/weapon/implant/reagent_generator/egg
+	name = "egg laying implant"
+	desc = "This is an implant that allows the user to lay eggs."
+	generated_reagents = list("egg" = 2)
+	usable_volume = 500
+	transfer_amount = 50
+
+	empty_message = list("Your lower belly feels smooth and empty. Sorry, we're out of eggs!", "The reduced pressure in your lower belly tells you there are no more eggs.")
+	full_message = list("Your lower belly looks swollen with irregular bumps, and it feels heavy.", "Your lower abdomen feels really heavy, making it a bit hard to walk.")
+	emote_descriptor = list("an egg right out of their belly!", "into their belly firmly, forcing them to lay an egg!", "them really tight, making them lay an egg promptly!")
+	var/verb_descriptor = list("squeezes", "pushes", "hugs")
+	var/self_verb_descriptor = list("squeeze", "push", "hug")
+	var/short_emote_descriptor = list("lays", "forces out", "pushes out")
+	self_emote_descriptor = list("lay", "force out", "push out")
+	random_emote = list("moans softly with a blush on their face", "yelps in embarrassment", "grunts a little")
+	assigned_proc = /mob/living/carbon/human/proc/use_reagent_implant_egg
+
+/obj/item/weapon/implant/reagent_generator/egg/implanted(mob/living/carbon/source)
+	processing_objects += src
+	to_chat(source, "<span class='notice'>You implant [source] with \the [src].</span>")
+	source.verbs |= assigned_proc
+	return 1
+
+/obj/item/weapon/implanter/reagent_generator/egg
+	implant_type = /obj/item/weapon/implant/reagent_generator/egg
+
+/mob/living/carbon/human/proc/use_reagent_implant_egg()
+	set name = "Lay Egg"
+	set desc = "Force them to lay an egg by squeezing into their lower body!"
+	set category = "Object"
+	set src in view(1)
+
+	//do_reagent_implant(usr)
+	if(!isliving(usr) || !usr.canClick())
+		return
+
+	if(usr.incapacitated() || usr.stat > CONSCIOUS)
+		return
+
+	var/obj/item/weapon/implant/reagent_generator/egg/rimplant
+	for(var/obj/item/organ/external/E in organs)
+		for(var/obj/item/weapon/implant/I in E.implants)
+			if(istype(I, /obj/item/weapon/implant/reagent_generator))
+				rimplant = I
+				break
+	if (rimplant)
+		if(rimplant.reagents.total_volume <= rimplant.transfer_amount)
+			to_chat(src, "<span class='notice'>[pick(rimplant.empty_message)]</span>")
+			return
+
+		new /obj/item/weapon/reagent_containers/food/snacks/egg(get_turf(src))
+
+		var/index = rand(0,3)
+
+		if (usr != src)
+			var/emote = rimplant.emote_descriptor[index]
+			var/verb_desc = rimplant.verb_descriptor[index]
+			var/self_verb_desc = rimplant.self_verb_descriptor[index]
+			usr.visible_message("<span class='notice'>[usr] [verb_desc] [emote]</span>",
+							"<span class='notice'>You [self_verb_desc] [emote]</span>")
+		else
+			visible_message("<span class='notice'>[src] [pick(rimplant.short_emote_descriptor)] an egg.</span>",
+								"<span class='notice'>You [pick(rimplant.self_emote_descriptor)] an egg.</span>")
+		if(prob(15))
+			visible_message("<span class='notice'>[src] [pick(rimplant.random_emote)].</span>") // M-mlem.
+
+		rimplant.reagents.remove_any(rimplant.transfer_amount)
+
 //WickedTempest: Chakat Tempest
 /obj/item/weapon/implant/reagent_generator/tempest
 	generated_reagents = list("milk" = 2)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1486,6 +1486,7 @@
 #include "code\modules\client\preference_setup\loadout\loadout_gloves_vr.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_head.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_head_vr.dm"
+#include "code\modules\client\preference_setup\loadout\loadout_implants.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_mask.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_shoes.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_shoes_vr.dm"


### PR DESCRIPTION
Adds a new category to the loadout, allowing you to select, for a cost of 2 loadout points, reagent generators mostly intended for RP purposes. At present, there's a choice of 🥚 and milk. Sorry, folks, no ham here! 😏 