### PR TITLE
Did you know teshari poncho sprites have been lurking in the code?

### DIFF
--- a/code/modules/clothing/under/accessories/clothing.dm
+++ b/code/modules/clothing/under/accessories/clothing.dm
@@ -49,7 +49,6 @@
 	desc = "A simple, comfortable poncho."
 	icon_state = "classicponcho"
 	item_state = "classicponcho"
-	icon_override = 'icons/mob/ties.dmi'
 	var/fire_resist = T0C+100
 	allowed = list(/obj/item/weapon/tank/emergency/oxygen)
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
@@ -61,7 +60,20 @@
 
 	sprite_sheets = list(
 		"Teshari" = 'icons/mob/species/seromi/suit.dmi'
-		)
+		) //This works only when wearing ponchos as an accessory, not a suit.
+
+/obj/item/clothing/accessory/poncho/equipped() //Solution for race-specific sprites for an accessory which is also a suit. Suit icons break if you don't use icon override which then also overrides race-specific sprites.
+	..()
+	var/mob/living/carbon/human/H = loc
+	if(istype(H) && H.wear_suit == src)
+		if(H.species.name == "Teshari")
+			icon_override = 'icons/mob/species/seromi/suit.dmi'
+		else
+			icon_override = 'icons/mob/ties.dmi'
+		update_clothing_icon()
+
+/obj/item/clothing/accessory/poncho/dropped() //Resets the override to prevent the wrong .dmi from being used because equipped only triggers when wearing ponchos as suits.
+	icon_override = null
 
 /obj/item/clothing/accessory/poncho/green
 	name = "green poncho"


### PR DESCRIPTION
Now they actually work.

Technical details:
-Removes "icon override" line from ponchos
-Icon override is now set on equipping ponchos in the outer clothing slot using ties.dmi for non-teshari and seromi/suit.dmi for teshari
-Icon override is set back to null when unequipped. This prevents bugs with the poncho icons as "equipped" does not trigger when wearing a poncho as an accessory, thus making it possible to use the wrong sprites if icon override is not reset.