### PR TITLE
Hotfix Message Spam

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -140,7 +140,7 @@
 		M.drowsyness = max(0, M.drowsyness - 3 * removed * chem_effective)
 		M.hallucination = max(0, M.hallucination - 6 * removed * chem_effective)
 		M.adjustToxLoss(-2 * removed * chem_effective)
-		
+
 /datum/reagent/carthatoline
 	name = "Carthatoline"
 	id = "carthatoline"
@@ -646,6 +646,8 @@
 	if(prob(60))
 		M.take_organ_damage(4 * removed, 0)
 
+//TFF 25/5/19 - attempt to reduce message spam for Prommies and Spaceacillin
+#define ANTIBIO_MESSAGE_DELAY 5*60*10
 /datum/reagent/spaceacillin
 	name = "Spaceacillin"
 	id = "spaceacillin"
@@ -658,17 +660,21 @@
 	overdose = REAGENTS_OVERDOSE
 	scannable = 1
 	data = 0
+	var/delay = 0
 
 /datum/reagent/spaceacillin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
+	if(!delay)
+		delay = world.time
 	if(alien == IS_SLIME)
-		if(volume <= 0.1 && data != -1)
-			data = -1
+		ingest_met = 0.25
+		if(volume <= 0.1 && data != -1 && world.time > delay + ANTIBIO_MESSAGE_DELAY)
+			delay = world.time
 			to_chat(M, "<span class='notice'>You regain focus...</span>")
 		else
-			var/delay = (5 MINUTES)
-			if(world.time > data + delay)
-				data = world.time
+			delay = (5 MINUTES)
+			if(world.time > delay + ANTIBIO_MESSAGE_DELAY)
+				delay = world.time
 				to_chat(M, "<span class='warning'>Your senses feel unfocused, and divided.</span>")
 	M.add_chemical_effect(CE_ANTIBIOTIC, dose >= overdose ? ANTIBIO_OD : ANTIBIO_NORM)
 
@@ -842,6 +848,7 @@
 
 #define ANTIDEPRESSANT_MESSAGE_DELAY 5*60*10
 
+//TFF 25/5/19 - Revert an edit, restore message display with the med being processed faster
 /datum/reagent/methylphenidate
 	name = "Methylphenidate"
 	id = "methylphenidate"
@@ -850,23 +857,22 @@
 	reagent_state = LIQUID
 	color = "#BF80BF"
 	metabolism = 0.01
+	ingest_met = 0.25
 	mrate_static = TRUE
 	data = 0
-	var/delay = 0
 
 /datum/reagent/methylphenidate/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(!delay)
-		delay = world.time
 	if(alien == IS_DIONA)
 		return
-	if(volume <= 0.1 && data != -1 && world.time > delay + ANTIDEPRESSANT_MESSAGE_DELAY)
-		delay = world.time
+	if(volume <= 0.1 && data != -1)
+		data = -1
 		M << "<span class='warning'>You lose focus...</span>"
 	else
-		if(world.time > delay + ANTIDEPRESSANT_MESSAGE_DELAY)
-			delay = world.time
+		if(world.time > data + ANTIDEPRESSANT_MESSAGE_DELAY)
+			data = world.time
 			M << "<span class='notice'>Your mind feels focused and undivided.</span>"
 
+//TFF 25/5/19 - Revert an edit, restore message display with the med being processed faster
 /datum/reagent/citalopram
 	name = "Citalopram"
 	id = "citalopram"
@@ -875,23 +881,22 @@
 	reagent_state = LIQUID
 	color = "#FF80FF"
 	metabolism = 0.01
+	ingest_met = 0.25
 	mrate_static = TRUE
 	data = 0
-	var/delay = 0
 
 /datum/reagent/citalopram/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(!delay)
-		delay = world.time
 	if(alien == IS_DIONA)
 		return
-	if(volume <= 0.1 && world.time > delay + ANTIDEPRESSANT_MESSAGE_DELAY)
-		delay = world.time
+	if(volume <= 0.1 && data != -1)
+		data = -1
 		to_chat(M, "<span class='warning'>Your mind feels a little less stable...</span>")
 	else
-		if(world.time > delay + ANTIDEPRESSANT_MESSAGE_DELAY)
-			delay = world.time
+		if(world.time > data + ANTIDEPRESSANT_MESSAGE_DELAY)
+			data = world.time
 			to_chat(M, "<span class='notice'>Your mind feels stable... a little stable.</span>")
 
+//TFF 25/5/19 - Revert an edit, restore message display with the med being processed faster
 /datum/reagent/paroxetine
 	name = "Paroxetine"
 	id = "paroxetine"
@@ -900,19 +905,19 @@
 	reagent_state = LIQUID
 	color = "#FF80BF"
 	metabolism = 0.01
+	ingest_met = 0.25
 	mrate_static = TRUE
 	data = 0
-	var/delay = 0
 
 /datum/reagent/paroxetine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return
-	if(volume <= 0.1 && world.time > delay + ANTIDEPRESSANT_MESSAGE_DELAY)
-		delay = world.time
+	if(volume <= 0.1 && data != -1)
+		data = -1
 		M << "<span class='warning'>Your mind feels much less stable...</span>"
 	else
-		if(world.time > delay + ANTIDEPRESSANT_MESSAGE_DELAY)
-			delay = world.time
+		if(world.time > data + ANTIDEPRESSANT_MESSAGE_DELAY)
+			data = world.time
 			if(prob(90))
 				M << "<span class='notice'>Your mind feels much more stable.</span>"
 			else
@@ -927,6 +932,7 @@
 	reagent_state = LIQUID
 	color = "#e6efe3"
 	metabolism = 0.01
+	ingest_met = 0.25
 	mrate_static = TRUE
 	data = 0
 

--- a/html/changelogs/Darlantanis - Mojito Sprite Fix.yml
+++ b/html/changelogs/Darlantanis - Mojito Sprite Fix.yml
@@ -1,0 +1,6 @@
+author: Darlantanis
+
+delete-after: True
+
+changes: 
+  - bugfix: "Adds a line to the metamorphic glass to use the mojito icon which has existed but never been used."

--- a/html/changelogs/Razgriz1032 - Lizard Tail greyscale.yml
+++ b/html/changelogs/Razgriz1032 - Lizard Tail greyscale.yml
@@ -1,0 +1,6 @@
+author: Razgriz1032
+
+delete-after: True
+
+changes:
+  - bugfix: "Colourable lizard tail (Roiz) sprite greyscaled for proper colouring."

--- a/html/changelogs/Razgriz1032 - Teshari security cloak.yml
+++ b/html/changelogs/Razgriz1032 - Teshari security cloak.yml
@@ -1,0 +1,6 @@
+author: Razgriz1032
+
+delete-after: True
+
+changes:
+  - tweak: "Teshari Security Cloak and Undercloak have 1:1 stats with security armor vests and security jumpsuits respectively. No longer is there a stats choice for the sake of aesthetics."

--- a/html/changelogs/TheFurryFeline - Message Spam Fixy.yml
+++ b/html/changelogs/TheFurryFeline - Message Spam Fixy.yml
@@ -1,0 +1,6 @@
+author: TheFurryFeline
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes message spam for Prommies and Spaceacillin. Also reverts a past edit to restore message outputs for psychiatric medications."


### PR DESCRIPTION
Fixes spammage stuff for Spaceacillin and Prommies. Revert an edit involving Psychiatric medications and increases rate of dispersal when ingested. This revert restores the fluff messages for them.