### PR TITLE
Mojito Sprite Fix

### DIFF
--- a/code/modules/reagents/reagent_containers/drinkingglass/metaglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/metaglass.dm
@@ -569,3 +569,6 @@ Drinks Data
 
 /datum/reagent/ethanol/hachi
 	glass_icon_state = "hachi"
+
+/datum/reagent/ethanol/mojito
+	glass_icon_state = "mojito"


### PR DESCRIPTION
Adds a line to the metamorphic glass to use the mojito icon which has existed but never been used.