### PR TITLE
Matcha fix

### DIFF
--- a/code/modules/food/recipes_microwave_vr.dm
+++ b/code/modules/food/recipes_microwave_vr.dm
@@ -237,3 +237,7 @@
 		/obj/item/weapon/reagent_containers/food/snacks/steamtealeaf
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/tencha
+	make_food(var/obj/container as obj)
+		var/obj/item/weapon/reagent_containers/food/snacks/validsalad/being_cooked = ..(container)
+		being_cooked.reagents.del_reagent("teamush")
+		return being_cooked

--- a/code/modules/reagents/reagent_containers/food/snacks_vr.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks_vr.dm
@@ -450,7 +450,6 @@
 /obj/item/weapon/reagent_containers/food/snacks/matchaleaf/New()
 	..()
 	reagents.add_reagent("matchapowder", 5)
-	reagents.remove_reagent("teamush", 5)
 	bitesize = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/sobakacube


### PR DESCRIPTION
Tea mush will now be properly deleted when making matcha, removing the need to separate it out with a chem master.