### PR TITLE
Timeclock Fixes

### DIFF
--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -170,6 +170,7 @@
 		foundjob.current_positions++
 		var/mob/living/carbon/human/H = usr
 		H.mind.assigned_role = foundjob.title
+		H.mind.role_alt_title = newjob	//TFF 26/7/19 - VOREStation fix port of announcement fix for wrong position
 		announce.autosay("[card.registered_name] has moved On-Duty as [card.assignment].", "Employee Oversight")
 	return
 
@@ -200,6 +201,7 @@
 		callHook("reassign_employee", list(card))
 		var/mob/living/carbon/human/H = usr
 		H.mind.assigned_role = ptojob.title
+		H.mind.role_alt_title = ptojob.title	//TFF 26/7/19 - VOREStation fix port of announcement fix for wrong position
 		foundjob.current_positions--
 		announce.autosay("[card.registered_name], [oldtitle], has moved Off-Duty.", "Employee Oversight")
 	return
@@ -208,7 +210,7 @@
 	if(!card)
 		return FALSE
 	if((world.time - card.last_job_switch) < 15 MINUTES)
-		to_chat(usr, "You need to wait at least 15 minutes after last duty switch. It has only been [world.time - card.last_job_switch] minutes since you have had your job changed.")
+		to_chat(usr, "You need to wait at least 15 minutes after last duty switch. It has only been [card.last_job_switch] minutes since you have had your job changed.")
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
Fixes time left output as well as for when the timeclock announces the wrong position when it was an alternate title, etc.: https://github.com/VOREStation/VOREStation/pull/5434