### PR TITLE
Attempt to fix Travis's unit test failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 env:
   global:
     - BYOND_MAJOR="512"
-    - BYOND_MINOR="1412"
+    - BYOND_MINOR="1448"
     - MACRO_COUNT=4
   matrix:
     - TEST_DEFINE="MAP_TEST" TEST_FILE="code/_map_tests.dm" RUN="0"


### PR DESCRIPTION
Something about corrupted map data, perhaps version maybe the issue. Updating to the version I use locally may fix this.

> 1.82s$ if [ $RUN -eq 1 ]; then DreamDaemon vorestation.dmb -invisible -trusted -core 2>&1 | tee log.txt; fi
Mon Aug 26 02:10:58 2019
World opened on network port 37281.
Welcome BYOND! (5.0 Beta Version 512.1412)
BYOND Error: corrupt map data in world file
The command "if [ $RUN -eq 1 ]; then DreamDaemon vorestation.dmb -invisible -trusted -core 2>&1 | tee log.txt; fi" exited with 0.

Seems like it doesn't actually know what it means, so hopefully by updating byond it might fix things?

I have edited the travis file by just changing the BYOND version, that's all.