### PR TITLE
Piranha Plant Vore Fix

### DIFF
--- a/code/modules/mob/living/simple_animal/animals/tomato.dm
+++ b/code/modules/mob/living/simple_animal/animals/tomato.dm
@@ -179,9 +179,8 @@
 /mob/living/simple_animal/hostile/piranhaplant/spitter/init_vore()
 	..()
 	var/obj/belly/B = vore_selected
-	B.vore_verb = "chomp up"
-	B.name = "stomach"
-	B.desc	= "You're pulled into the tight stomach of the plant. The walls knead weakly around you, coating you in thick, viscous fluids that cling to your body, that soon starts to tingle and burn..."
+	B.vore_verb = "slurped up"
+	B.desc	= "You're pulled into the tight mouth of the plant. The tongue mulls you about and squishes you around, coating you in a slurry of digestive fluides that burn hotly and smell foul."
 	B.digest_burn = 5
 	B.digest_brute = 0
 
@@ -229,6 +228,7 @@
 /mob/living/simple_animal/hostile/piranhaplant/pitcher/init_vore()
 	..()
 	var/obj/belly/B = vore_selected
+	B.desc	= "You're pulled into the tight stomach of the plant. The walls knead weakly around you, coating you in thick, viscous fluids that cling to your body, that soon starts to tingle and burn..."
 	B.digest_burn = 0.5
 	B.digest_brute = 0
 	B.vore_verb = "slurp up"

--- a/code/modules/mob/living/simple_animal/animals/tomato.dm
+++ b/code/modules/mob/living/simple_animal/animals/tomato.dm
@@ -172,9 +172,18 @@
 	var/obj/belly/B = vore_selected
 	B.vore_verb = "chomp up"
 	B.name = "stomach"
-	B.desc	= "You're pulled into the tight stomach of the plant. The walls knead weakly around you, coating you in thick, viscous fluids that cling to your body, that soon starts to tingle and burn..."
+	B.desc	= "You're pulled into the tight mouth of the plant. The teeth and walls gnash harshly on you!"
 	B.digest_burn = 0
-	B.digest_brute = 12
+	B.digest_brute = 5
+	
+/mob/living/simple_animal/hostile/piranhaplant/spitter/init_vore()
+	..()
+	var/obj/belly/B = vore_selected
+	B.vore_verb = "chomp up"
+	B.name = "stomach"
+	B.desc	= "You're pulled into the tight stomach of the plant. The walls knead weakly around you, coating you in thick, viscous fluids that cling to your body, that soon starts to tingle and burn..."
+	B.digest_burn = 5
+	B.digest_brute = 0
 
 /mob/living/simple_animal/hostile/piranhaplant/pitcher
 	icon_state = "pitcher-plant"


### PR DESCRIPTION
+Piranha plant now has proper descriptor describing digestion brute damage.
-Brute damage per tick reduced from 12 since it was essentially a car compactor. Broken bones. All of them.

+Spitter plant now deals digestion burn damage instead of 12 brute damage.
-Deals 5 burn damage per tick.

