### PR TITLE
ghosts don't wormhole

### DIFF
--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -48,6 +48,8 @@
 	teleport(user)
 
 /obj/effect/portal/worm/teleport(atom/movable/M)
+	if(istype(M, /mob/observer))
+		return
 	if(istype(M, /obj/effect))	//sparks don't teleport
 		return
 	if(M.anchored && istype(M, /obj/mecha))


### PR DESCRIPTION
because of reasons, ghosts can no longer trigger wormholes, sorry bored observers!