### PR TITLE
advanced first aid

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -88,7 +88,7 @@
 	item_state_slots = list(slot_r_hand_str = "firstaid-advanced", slot_l_hand_str = "firstaid-advanced")
 	starts_with = list(
 		/obj/item/weapon/reagent_containers/hypospray/autoinjector,
-		/obj/item/stack/medical/advanced/bruise_pack,
+		/obj/item/device/healthanalyzer,
 		/obj/item/stack/medical/advanced/bruise_pack,
 		/obj/item/stack/medical/advanced/bruise_pack,
 		/obj/item/stack/medical/advanced/ointment,


### PR DESCRIPTION
advanced first aid kits now spawn with a health analyzer so that medical always starts with one instead of needing to run to medbay before diagnosing anybody just because they have the better kit.

lose out on a trauma kit, rebalancing it to 2 trauma kits and 2 burn kits. instead of 3-2