### PR TITLE
Fixes red carpet from creating rainbow carpet.

### DIFF
--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -158,7 +158,7 @@ var/list/flooring_types
 /decl/flooring/carpet/rainbowcarpet
 	name = "rainbow carpet"
 	icon_base = "rainbowcarpet"
-//	build_type = /obj/item/stack/tile/carpet/rainbow
+	build_type = /obj/item/stack/tile/carpet/rainbowcarpet
 
 /decl/flooring/tiling
 	name = "floor"


### PR DESCRIPTION
Uncomments out the material used to make rainbow carpet and corrects the object path from "rainbow" to "rainbowcarpet."