### PR TITLE
Fix early-joining and alt-job title preference

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -59,8 +59,6 @@ var/global/datum/controller/occupations/job_master
 				return 0
 			if(!job.player_old_enough(player.client))
 				return 0
-			if(!check_whitelist(player)) // Yeah no, no more hardcoded whitelisting. Ree. - Jon.
-				return 0
 			if(!is_job_whitelisted(player, rank)) //VOREStation Code
 				return 0
 


### PR DESCRIPTION
Removed two lines of code that was FORCING the game to look at the whitelist to even allow early joiners a job/role and their own job title.