### PR TITLE
Boss Event Fixy

### DIFF
--- a/code/game/area/Space Station 13 areas_vr.dm
+++ b/code/game/area/Space Station 13 areas_vr.dm
@@ -248,3 +248,13 @@
 /area/engineering/engine_gas
 	name = "\improper Engine Gas Storage"
 	icon_state = "engine_waste"
+
+//CHOMPStation Addition Start - TFF 24/11/19 - New areas for Chapel Maint.
+/area/maintenance/chapel_aft
+	name = "Chapel Maintenance - Aft"
+	icon_state = "maint_chapel"
+
+/area/maintenance/chapel_fore
+	name = "Chapel Maintenance - Fore"
+	icon_state = "maint_chapel"
+//CHOMPStation Addition End

--- a/code/modules/events/boss.dm
+++ b/code/modules/events/boss.dm
@@ -2,7 +2,7 @@
 #define LOC_CHAPEL 1
 #define LOC_LIBRARY 2
 #define LOC_GARDEN 3
-#define LOC_MAINTENANCE 4 
+#define LOC_MAINTENANCE 4
 #define LOC_CONSTR 5
 
 #define BOSS_METROID 0
@@ -102,7 +102,7 @@
 #undef LOC_CHAPEL
 #undef LOC_LIBRARY
 #undef LOC_GARDEN
-#undef LOC_MAINTENANCE 
+#undef LOC_MAINTENANCE
 #undef LOC_CONSTR
 
 #undef BOSS_METROID

--- a/code/modules/events/boss.dm
+++ b/code/modules/events/boss.dm
@@ -42,7 +42,7 @@
 			spawn_area_type = /area/hydroponics/garden
 			locstring = "the public garden"
 		if(LOC_MAINTENANCE)
-			spawn_area_type = /area/maintenance/locker
+			spawn_area_type = /area/maintenance/chapel_fore
 			locstring = "far northern maintenance tunnels"
 		if(LOC_CONSTR)
 			spawn_area_type = /area/construction

--- a/maps/northern_star/northern_star_areas.dm
+++ b/maps/northern_star/northern_star_areas.dm
@@ -26,14 +26,6 @@
 	name = "Mining Outpost Emergency Storage"
 
 //TFF 28/9/19 - Add more areas. Again.
-/area/maintenance/chapel_aft
-	name = "Chapel Maintenance - Aft"
-	icon_state = "maint_chapel"
-
-/area/maintenance/chapel_fore
-	name = "Chapel Maintenance - Fore"
-	icon_state = "maint_chapel"
-
 /area/crew_quarters/bar_backroom
 	name = "Bar Backroom"
 	icon_state = "bar"


### PR DESCRIPTION
Used to be for Locker Room Maint, which was a dumb name for a maint that's in the FORE of the Chapel area, so... chapel_fore it is.

Changelog Note:

- Fixes Boss Event not spawning a map in the Chapel Maint area as intended.